### PR TITLE
Remove `constexpr` from LSHPair

### DIFF
--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -45,7 +45,7 @@ bool OPTSCHED_gPrintSpills;
 
 // An array of possible OptSched heuristic names
 #define LSHPair std::pair<const char *, LISTSCHED_HEURISTIC>
-static constexpr LSHPair HeuristicNames[] = {
+static LSHPair HeuristicNames[] = {
     LSHPair("CP", LSH_CP),    LSHPair("LUC", LSH_LUC),
     LSHPair("UC", LSH_UC),    LSHPair("NID", LSH_NID),
     LSHPair("CPR", LSH_CPR),  LSHPair("ISO", LSH_ISO),


### PR DESCRIPTION
std::pair is not constexpr in C++11, only in C++14 and later.

Closes #10