### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -19,9 +19,10 @@ class ACOScheduler : public ConstrainedScheduler {
 public:
   ACOScheduler(DataDepGraph *dataDepGraph, MachineModel *machineModel,
                InstCount upperBound, SchedPriorities priorities);
-  virtual ~ACOScheduler();
-  FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region);
-  inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
+  ~ACOScheduler() override;
+  FUNC_RESULT FindSchedule(InstSchedule *schedule,
+                           SchedRegion *region) override;
+  inline void UpdtRdyLst_(InstCount cycleNum, int slotNum) override;
 
 private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);
@@ -35,7 +36,7 @@ private:
   void UpdatePheremone(InstSchedule *schedule);
   InstSchedule *FindOneSchedule();
   pheremone_t *pheremone_;
-  pheremone_t initialValue_;
+  pheremone_t initialValue_{};
   bool use_fixed_bias;
   int count_;
   int heuristicImportance_;
@@ -46,7 +47,9 @@ private:
   double decay_factor;
   int ants_per_iteration;
   bool print_aco_trace;
-  std::vector<double> scores(std::vector<Choice> ready, SchedInstruction *last);
+  // FIXME: Unused method
+  std::vector<double> scores(const std::vector<Choice> &ready,
+                             SchedInstruction *last);
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -31,6 +31,7 @@ private:
   LengthCostEnumerator *enumrtr_;
 
   InstCount crntSpillCost_;
+  // FIXME: Unused variable
   InstCount optmlSpillCost_;
 
   // The target machine
@@ -64,7 +65,9 @@ private:
   // calculated.
   InstCount dynamicSlilLowerBound_ = 0;
 
+  // FIXME: Unused variable
   int entryInstCnt_;
+  // FIXME: Unused variable
   int exitInstCnt_;
   int schduldEntryInstCnt_;
   int schduldExitInstCnt_;
@@ -78,36 +81,41 @@ private:
   InstCount peakSpillCost_;
   InstCount totSpillCost_;
   InstCount slilSpillCost_;
+  // FIXME: Unused variable
   bool trackLiveRangeLngths_;
 
   // Virtual Functions:
   // Given a schedule, compute the cost function value
   InstCount CmputNormCost_(InstSchedule *sched, COST_COMP_MODE compMode,
-                           InstCount &execCost, bool trackCnflcts);
+                           InstCount &execCost, bool trackCnflcts) override;
   InstCount CmputCost_(InstSchedule *sched, COST_COMP_MODE compMode,
-                       InstCount &execCost, bool trackCnflcts);
-  void CmputSchedUprBound_();
-  Enumerator *AllocEnumrtr_(Milliseconds timeout);
+                       InstCount &execCost, bool trackCnflcts) override;
+  void CmputSchedUprBound_() override;
+  Enumerator *AllocEnumrtr_(Milliseconds timeout) override;
   FUNC_RESULT Enumerate_(Milliseconds startTime, Milliseconds rgnDeadline,
-                         Milliseconds lngthDeadline);
-  void SetupForSchdulng_();
-  void FinishHurstc_();
-  void FinishOptml_();
-  void CmputAbslutUprBound_();
-  ConstrainedScheduler *AllocHeuristicScheduler_();
-  bool EnableEnum_();
+                         Milliseconds lngthDeadline) override;
+  void SetupForSchdulng_() override;
+  void FinishHurstc_() override;
+  void FinishOptml_() override;
+  void CmputAbslutUprBound_() override;
+  ConstrainedScheduler *AllocHeuristicScheduler_() override;
+  bool EnableEnum_() override;
 
   // BBWithSpill-specific Functions:
+  // FIXME: Not implemented
   InstCount CmputCostLwrBound_(InstCount schedLngth);
+  // FIXME: Not implemented
   InstCount CmputCostLwrBound_();
   void InitForCostCmputtn_();
+  // FIXME: Not implemented
   InstCount CmputDynmcCost_();
 
   void UpdateSpillInfoForSchdul_(SchedInstruction *inst, bool trackCnflcts);
   void UpdateSpillInfoForUnSchdul_(SchedInstruction *inst);
   void SetupPhysRegs_();
   void CmputCrntSpillCost_();
-  bool ChkSchedule_(InstSchedule *bestSched, InstSchedule *lstSched);
+  bool ChkSchedule_(InstSchedule *bestSched, InstSchedule *lstSched) override;
+  // FIXME: Unused method
   void CmputCnflcts_(InstSchedule *sched);
 
 public:
@@ -117,24 +125,24 @@ public:
               bool vrfySched, Pruning PruningStrategy, bool SchedForRPOnly,
               bool enblStallEnum, int SCW, SPILL_COST_FUNCTION spillCostFunc,
               SchedulerType HeurSchedType);
-  ~BBWithSpill();
+  ~BBWithSpill() override;
 
-  int CmputCostLwrBound();
+  int CmputCostLwrBound() override;
 
   InstCount UpdtOptmlSched(InstSchedule *crntSched,
-                           LengthCostEnumerator *enumrtr);
-  bool ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *treeNode);
+                           LengthCostEnumerator *enumrtr) override;
+  bool ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *treeNode) override;
   void SchdulInst(SchedInstruction *inst, InstCount cycleNum, InstCount slotNum,
-                  bool trackCnflcts);
+                  bool trackCnflcts) override;
   void UnschdulInst(SchedInstruction *inst, InstCount cycleNum,
-                    InstCount slotNum, EnumTreeNode *trgtNode);
-  void SetSttcLwrBounds(EnumTreeNode *node);
-  bool ChkInstLglty(SchedInstruction *inst);
-  void InitForSchdulng();
+                    InstCount slotNum, EnumTreeNode *trgtNode) override;
+  void SetSttcLwrBounds(EnumTreeNode *node) override;
+  bool ChkInstLglty(SchedInstruction *inst) override;
+  void InitForSchdulng() override;
 
 protected:
   // (Chris)
-  inline virtual const std::vector<int> &GetSLIL_() const {
+  inline const std::vector<int> &GetSLIL_() const override {
     return sumOfLiveIntervalLengths_;
   }
 };

--- a/include/opt-sched/Scheduler/buffers.h
+++ b/include/opt-sched/Scheduler/buffers.h
@@ -18,6 +18,7 @@ namespace llvm {
 namespace opt_sched {
 
 const int INBUF_MAX_PIECES_PERLINE = 30;
+// FIXME: Unused variable
 const int INBUF_MAX_LINESIZE = 10000;
 const int DFLT_INPBUF_SIZE = 1000000;
 
@@ -46,9 +47,9 @@ public:
   void Unload();
   char *GetBuf() { return buf; }
   char const *GetFullPath() const { return fullPath; }
-  FUNC_RESULT Load(char const *const fileName, char const *const path,
+  FUNC_RESULT Load(char const *fileName, char const *path,
                    long maxByts = DFLT_INPBUF_SIZE);
-  FUNC_RESULT Load(char const *const fullPath, long maxByts = DFLT_INPBUF_SIZE);
+  FUNC_RESULT Load(char const *fullPath, long maxByts = DFLT_INPBUF_SIZE);
   FUNC_RESULT SetBuf(char *buf, long size);
 
   // This function skips all comments and white spaces (tabs are not taken
@@ -85,8 +86,8 @@ protected:
   NXTLINE_TYPE GetNxtVldLine_(int &pieceCnt, char *str[], int lngth[],
                               int maxPieceCnt = INBUF_MAX_PIECES_PERLINE);
   bool IsWhiteSpaceOrLineEnd(char ch);
-  void ReportError(char *msg, char *lineStrt, int frstLngth);
-  void ReportFatalError(char *msg, char *lineStrt, int frstLngth);
+  void ReportError(char *msg, char *lineStart, int frstLngth);
+  void ReportFatalError(char *msg, char *lineStart, int frstLngth);
 };
 
 // A specs buffer is an input buffer for parsing a typical input specification
@@ -96,17 +97,21 @@ protected:
 class SpecsBuffer : public InputBuffer {
 public:
   SpecsBuffer();
-  void ReadSpec(char const *const title, char *value);
+  void ReadSpec(char const *title, char *value);
   void readLine(char *value, int maxPieceCnt);
   void readLstElmnt(char *value);
+  // FIXME: Unused method
   int readIntLstElmnt();
-  bool ReadFlagSpec(char const *const title, bool dfltValue);
-  unsigned long ReadUlongSpec(char const *const title);
-  float ReadFloatSpec(char const *const title);
-  uint64_t readUInt64Spec(char const *const title);
-  int ReadIntSpec(char const *const title);
-  int16_t ReadShortSpec(char const *const title);
-  FUNC_RESULT checkTitle(char const *const title);
+  bool ReadFlagSpec(char const *title, bool dfltValue);
+  // FIXME: Unused method
+  unsigned long ReadUlongSpec(char const *title);
+  float ReadFloatSpec(char const *title);
+  // FIXME: Unused method
+  uint64_t readUInt64Spec(char const *title);
+  int ReadIntSpec(char const *title);
+  // FIXME: Unused method
+  int16_t ReadShortSpec(char const *title);
+  FUNC_RESULT checkTitle(char const *title);
   void ErrorHandle(char *value);
 
 protected:

--- a/include/opt-sched/Scheduler/config.h
+++ b/include/opt-sched/Scheduler/config.h
@@ -36,11 +36,14 @@ public:
   int64_t GetInt(const string &name) const;
   int64_t GetInt(const string &name, int64_t default_) const;
   float GetFloat(const string &name) const;
+  // FIXME: Unused method
   float GetFloat(const string &name, float default_) const;
   bool GetBool(const string &name) const;
   bool GetBool(const string &name, bool default_) const;
   list<string> GetStringList(const string &name) const;
+  // FIXME: Unused method
   list<int64_t> GetIntList(const string &name) const;
+  // FIXME: Unused method
   list<float> GetFloatList(const string &name) const;
 
 protected:
@@ -59,7 +62,7 @@ public:
   void operator=(SchedulerOptions const &) = delete;
 
 private:
-  SchedulerOptions() {}
+  SchedulerOptions() = default;
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -81,16 +81,13 @@ enum SUB_GRAPH_TYPE {
 };
 
 // TODO(max): Document.
+// Fixme: Unused variable
 const size_t MAX_INSTNAME_LNGTH = 160;
-
-// An extra to be added to the absolute upper bound. This is a hack to fix some
-// elusive legacy bug which may or may not exist anymore.
-// TODO(ghassan): Eliminate.
-const int SCHED_UB_EXTRA = 20;
 
 const int MAX_LATENCY_VALUE = 10;
 
 // The total number of possible graph transformations.
+// Fixme: Unused variable
 const int NUM_GRAPH_TRANS = 1;
 
 // Forward declarations used to reduce the number of #includes.
@@ -108,11 +105,12 @@ class GraphTrans;
 class DataDepStruct {
 public:
   // TODO(max): Document.
-  DataDepStruct(MachineModel *machMdl);
+  explicit DataDepStruct(MachineModel *machMdl);
   // TODO(max): Document.
   virtual ~DataDepStruct();
 
   virtual InstCount GetInstCnt();
+  // Fixme: Unused method
   virtual InstCount GetOrgnlInstCnt();
   virtual SchedInstruction *GetInstByIndx(InstCount instIndx) = 0;
   virtual SchedInstruction *GetInstByTplgclOrdr(InstCount ordr) = 0;
@@ -133,6 +131,7 @@ public:
                             InstCount *&bkwrdLwrBounds);
   virtual InstCount GetRltvCrtclPath(SchedInstruction *ref,
                                      SchedInstruction *inst, DIRECTION dir) = 0;
+  // Fixme: Unused method
   virtual InstCount GetDistFrmLeaf(SchedInstruction *inst) = 0;
 
 protected:
@@ -174,26 +173,30 @@ class DataDepGraph : public llvm::opt_sched::OptSchedDDGWrapperBase,
                      public DataDepStruct {
 public:
   DataDepGraph(MachineModel *machMdl, LATENCY_PRECISION ltncyPcsn);
-  virtual ~DataDepGraph();
+  ~DataDepGraph() override;
 
   // Reads the data dependence graph from a text file.
+  // FIXME: Unused method
   FUNC_RESULT ReadFrmFile(SpecsBuffer *buf, bool &endOfFileReached);
   // Continues reading until the end of the current graph definition,
   // discarding the data.
+  // FIXME: Unused method
   FUNC_RESULT SkipGraph(SpecsBuffer *buf, bool &endOfFileReached);
   // Writes the data dependence graph to a text file.
+  // FIXME: Unused method
   FUNC_RESULT WriteToFile(FILE *file, FUNC_RESULT rslt, InstCount imprvmnt,
                           long number);
   // Returns the string ID of the graph as read from the input file.
   const char *GetDagID() const;
   // Returns the weight of the graph, as read from the input file.
+  // FIXME: Unused method
   float GetWeight() const;
 
   // Given an instruction number, return a pointer to the instruction object.
-  SchedInstruction *GetInstByIndx(InstCount instIndx);
+  SchedInstruction *GetInstByIndx(InstCount instIndx) override;
 
-  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr);
-  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr);
+  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr) override;
+  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr) override;
 
   // Setup the Dep. Graph for scheduling by doing a topological sort
   // followed by critical path computation
@@ -209,6 +212,7 @@ public:
   void EnableBackTracking();
 
   void GetCrntLwrBounds(DIRECTION dir, InstCount crntlwrBounds[]);
+  // FIXME: Unused method
   void SetCrntLwrBounds(DIRECTION dir, InstCount crntlwrBounds[]);
 
   SchedInstruction *GetRootInst();
@@ -225,13 +229,17 @@ public:
   // Get the lower and upper bounds read from the input file
   void GetFileSchedBounds(InstCount &lwrBound, InstCount &uprBound) const;
 
+  // FIXME: Unused method
   InstCount GetFileSchedLngth() { return fileSchedLngth_; }
+  // FIXME: Unused method
   InstCount GetAdjustedFileSchedCycle(InstCount instNum);
 
   // Get the target upper bound from the input file
+  // FIXME: Unused method
   InstCount GetFileSchedTrgtUprBound();
 
   // Get the final lower and upper bounds
+  // FIXME: Unused method
   void GetFinalBounds(InstCount &lwrBound, InstCount &uprBound);
 
   // Set the final lower and upper bounds
@@ -241,46 +249,59 @@ public:
 
   // Add edges to enforce the original program order, assuming that
   // it is represented by the instruction numbers
+  // FIXME: Unused method
   void EnforceProgOrder();
 
   bool UseFileBounds();
-  void PrintLwrBounds(DIRECTION dir, std::ostream &out,
-                      char const *const title);
+  void PrintLwrBounds(DIRECTION dir, std::ostream &out, char const *title);
+  // FIXME: Unused method
   void RestoreAbsoluteBounds();
 
+  // FIXME: Unused method
   void PrintInstTypeInfo(FILE *file);
 
   // Count dependences and cross-dependences
+  // FIXME: Unused method
   void CountDeps(InstCount &totDepCnt, InstCount &crossDepCnt);
 
+  // FIXME: Unused method
   int GetBscBlkCnt();
-  bool IsInGraph(SchedInstruction *inst);
-  InstCount GetInstIndx(SchedInstruction *inst);
+  bool IsInGraph(SchedInstruction *inst) override;
+  InstCount GetInstIndx(SchedInstruction *inst) override;
   InstCount GetRltvCrtclPath(SchedInstruction *ref, SchedInstruction *inst,
-                             DIRECTION dir);
+                             DIRECTION dir) override;
   void SetCrntFrwrdLwrBound(SchedInstruction *inst);
   void SetSttcLwrBounds();
   void SetDynmcLwrBounds();
   void CreateEdge(SchedInstruction *frmNode, SchedInstruction *toNode,
                   int ltncy, DependenceType depType);
-  InstCount GetDistFrmLeaf(SchedInstruction *inst);
+  InstCount GetDistFrmLeaf(SchedInstruction *inst) override;
 
+  // FIXME: Unused method
   void SetPrblmtc();
+  // FIXME: Unused method
   bool IsPrblmtc();
 
+  // FIXME: Unused method
   bool IncludesUnsupported();
+  // FIXME: Unused method
   bool IncludesNonStandardBlock();
+  // FIXME: Unused method
   bool IncludesCall();
 
+  // FIXME: Unused method
   InstCount GetRealInstCnt();
+  // FIXME: Unused method
   InstCount GetCodeSize();
   void SetHard(bool isHard);
+  // FIXME: Unused method
   bool IsHard() { return isHard_; }
 
   int GetEntryInstCnt() { return entryInstCnt_; }
   int GetExitInstCnt() { return exitInstCnt_; }
 
   InstCount GetMaxFileSchedOrder() { return maxFileSchedOrder_; }
+  // FIXME: Unused method
   void PrintEdgeCntPerLtncyInfo();
 
   int16_t GetMaxUseCnt() { return maxUseCnt_; }
@@ -329,6 +350,7 @@ protected:
 
   // The length of some known schedule that has been computed by some other
   // program ,e.g., gcc when the input DAGs come from gcc
+  // FIXME: Unused variable
   InstCount knwnSchedLngth_;
 
   // A list of DDG mutations
@@ -336,6 +358,7 @@ protected:
 
   MachineModel *machMdl_;
 
+  // FIXME: Unused variable
   bool backTrackEnbl_;
 
   char dagID_[MAX_NAMESIZE];
@@ -389,6 +412,7 @@ protected:
                                 int nodeID, InstCount fileSchedOrder,
                                 InstCount fileSchedCycle, InstCount fileLB,
                                 InstCount fileUB, int blkNum);
+  // FIXME: Unused variable
   void AddNode_(SchedInstruction *instPtr, InstCount instNum);
   FUNC_RESULT FinishNode_(InstCount nodeNum, InstCount edgeCnt = -1);
   void CreateEdge_(InstCount frmInstNum, InstCount toInstNum, int ltncy,
@@ -417,6 +441,7 @@ protected:
 
   InstCount maxInstCnt_;
   InstCount extrnlInstCnt_;
+  // FIXME: Unused variable
   InstCount cmpnstdInstCnt_;
   bool instsChngd_;
   bool instAdded_;
@@ -441,6 +466,7 @@ protected:
   bool dynmcLwrBoundsSet_;
   InstCount *dynmcFrwrdLwrBounds_;
   InstCount *dynmcBkwrdLwrBounds_;
+  // FIXME: Unused variable
   LinkedList<SchedInstruction> *fxdLst_;
 
   typedef struct {
@@ -453,9 +479,11 @@ protected:
   // The total lower bound that also includes the gap size
   InstCount totLwrBound_;
   InstCount unstsfidLtncy_;
+  // FIXME: Unused variable
   InstCount rejoinCycle_;
 
 #ifdef IS_DEBUG
+  // FIXME: Unused variable
   int errorCnt_;
 #endif
 
@@ -467,6 +495,7 @@ protected:
   void DelRootAndLeafInsts_(bool isFinal);
   void Clear_();
   void InitForLwrBounds_();
+  // FIXME: Unused method
   void InitForDynmcLwrBounds_();
   void UpdtSttcLwrBounds_();
   void RmvExtrnlInsts_();
@@ -474,14 +503,18 @@ protected:
   void SetRootsAndLeaves_();
   bool IsRoot_(SchedInstruction *inst);
   bool IsLeaf_(SchedInstruction *inst);
+  // FIXME: Unimplemented method
   InstCount CmputCrtclPath_();
   void CreateEdge_(SchedInstruction *frmInst, SchedInstruction *toInst);
+  // FIXME: Unused method
   void RmvEdge_(SchedInstruction *frmInst, SchedInstruction *toInst);
   void CmputCrtclPaths_(DIRECTION dir);
   void CmputCrtclPaths_();
+  // FIXME: Unused method
   void FindFrstCycleRange_(InstCount &minFrstCycle, InstCount &maxFrstCycle);
   InstCount GetRealInstCnt_();
 
+  // FIXME: Unused method
   bool TightnDynmcLwrBound_(InstCount frstCycle, InstCount minLastCycle,
                             InstCount maxLastCycle, InstCount trgtLwrBound,
                             InstCount &dynmcLwrBound);
@@ -496,6 +529,7 @@ protected:
   bool ChkInstRanges_(InstCount lastCycle);
   bool ChkInstRange_(SchedInstruction *inst, InstCount indx,
                      InstCount lastCycle);
+  // FIXME: Unused method
   bool CmputSmplDynmcLwrBound_(InstCount &dynmcLwrBound, InstCount trgtLwrBound,
                                bool &trgtFsbl);
   InstCount CmputTwoInstDynmcLwrBound_();
@@ -503,7 +537,9 @@ protected:
 
   void AddRoot_(SchedInstruction *inst);
   void AddLeaf_(SchedInstruction *inst);
+  // FIXME: Unused method
   void RmvLastRoot_(SchedInstruction *inst);
+  // FIXME: Unused method
   void RmvLastLeaf_(SchedInstruction *inst);
 
   void PropagateFrwrdLwrBounds_(InstCount frmIndx, InstCount toIndx,
@@ -513,8 +549,10 @@ protected:
   void TightnLwrBound_(DIRECTION dir, InstCount indx, InstCount lwrBounds[]);
   void AllocSttcData_();
   void AllocDynmcData_();
+  // FIXME: Unused method
   InstCount CmputMaxReleaseTime_();
   InstCount CmputMaxDeadline_();
+  // FIXME: Unused method
   bool CmputEntTrmnlDynmcLwrBound_(InstCount &dynmcLwrBound,
                                    InstCount trgtLwrBound);
   InstCount GetLostInstCnt_();
@@ -529,13 +567,16 @@ protected:
   void AllocRlxdSchdulr_(LB_ALG lbAlg, RelaxedScheduler *&rlxdSchdulr,
                          RelaxedScheduler *&rvrsRlxdSchdulr);
   void FreeRlxdSchdulr_(LB_ALG lbAlg);
-  InstCount CmputAbslutUprBound_();
+  InstCount CmputAbslutUprBound_() override;
 
 public:
+  // FIXME: Unused method
   DataDepSubGraph(DataDepGraph *fullGraph, InstCount maxInstCnt,
                   MachineModel *machMdl);
-  virtual ~DataDepSubGraph();
+  ~DataDepSubGraph() override;
+  // FIXME: Unused method
   void InitForSchdulng(bool clearAll);
+  // FIXME: Unused method
   void SetupForDynmcLwrBounds(InstCount schedUprBound);
   void AddInst(SchedInstruction *inst);
   void RmvInst(SchedInstruction *inst);
@@ -544,31 +585,39 @@ public:
                           InstCount rejoinCycle, SchedInstruction *inst,
                           InstCount &instGapSize);
 
+  // FIXME: Unused method
   void CmputTotLwrBound(LB_ALG lbAlg, InstCount rejoinCycle,
                         SchedInstruction *inst, InstCount &lwrBound,
                         InstCount &unstsfidLtncy, bool &crtnRejoin,
                         InstCount &instGapSize);
 
+  // FIXME: Unused method
   InstCount GetLwrBound();
-  SchedInstruction *GetInstByIndx(InstCount instIndx);
-  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr);
-  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr);
+  SchedInstruction *GetInstByIndx(InstCount instIndx) override;
+  SchedInstruction *GetInstByTplgclOrdr(InstCount ordr) override;
+  SchedInstruction *GetInstByRvrsTplgclOrdr(InstCount ordr) override;
 
-  SchedInstruction *GetRootInst();
-  SchedInstruction *GetLeafInst();
-  bool IsInGraph(SchedInstruction *inst);
-  InstCount GetInstIndx(SchedInstruction *inst);
+  SchedInstruction *GetRootInst() override;
+  SchedInstruction *GetLeafInst() override;
+  bool IsInGraph(SchedInstruction *inst) override;
+  InstCount GetInstIndx(SchedInstruction *inst) override;
   InstCount GetRltvCrtclPath(SchedInstruction *ref, SchedInstruction *inst,
-                             DIRECTION dir);
+                             DIRECTION dir) override;
 
+  // FIXME: Unused method
   void AddExtrnlInst(SchedInstruction *inst);
+  // FIXME: Unused method
   void RmvExtrnlInst(SchedInstruction *inst);
-  InstCount GetDistFrmLeaf(SchedInstruction *inst);
-  void GetLwrBounds(InstCount *&frwrdLwrBounds, InstCount *&bkwrdLwrBounds);
-  InstCount GetOrgnlInstCnt();
+  InstCount GetDistFrmLeaf(SchedInstruction *inst) override;
+  void GetLwrBounds(InstCount *&frwrdLwrBounds,
+                    InstCount *&bkwrdLwrBounds) override;
+  InstCount GetOrgnlInstCnt() override;
 
+  // FIXME: Unused method
   void InstLost(SchedInstruction *inst);
+  // FIXME: Unused method
   void UndoInstLost(SchedInstruction *inst);
+  // FIXME: Unused method
   InstCount GetAvlblSlots(IssueType issuType);
 };
 /*****************************************************************************/
@@ -662,6 +711,7 @@ public:
   // If the current slot contains a fixed instruction this function fails
   bool AppendInst(InstCount instNum);
 
+  // FIXME: Unused method
   bool AppendInst(SchedInstruction *inst);
 
   // Remove the last instruction scheduled
@@ -674,6 +724,7 @@ public:
   void SetCost(InstCount cost);
   InstCount GetCost() const;
   void SetExecCost(InstCount cost);
+  // FIXME: Unused method
   InstCount GetExecCost() const;
   void SetSpillCost(InstCount cost);
   InstCount GetSpillCost() const;
@@ -691,17 +742,24 @@ public:
   void SetPeakRegPressures(InstCount *regPressures);
   InstCount GetPeakRegPressures(const InstCount *&regPressures) const;
   InstCount GetSpillCost(InstCount stepNum);
+  // FIXME: Unused method
   InstCount GetTotSpillCost();
+  // FIXME: Unused method
   int GetConflictCount();
   void SetConflictCount(int cnflctCnt);
+  // FIXME: Unused method
   int GetSpillCandidateCount();
+  // FIXME: Unused method
   void SetSpillCandidateCount(int cnflctCnt);
 
-  void Print(std::ostream &out, char const *const title);
+  void Print(std::ostream &out, char const *title);
+  // FIXME: Unused method
   void PrintInstList(FILE *file, DataDepGraph *dataDepGraph,
                      const char *title) const;
+  // FIXME: Unimplemented method
   void PrintRegPressures() const;
   bool Verify(MachineModel *machMdl, DataDepGraph *dataDepGraph);
+  // FIXME: Unused method
   void PrintClassData();
 };
 /*****************************************************************************/

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -90,8 +90,10 @@ enum SPILL_COST_FUNCTION {
 typedef UDT_HASHKEY InstSignature;
 
 // The cycle or slot number of an instruction node which has not been scheduled.
+// FIXME: Unused variable
 const int SCHD_UNSCHDULD = -1;
 // TODO(ghassan): Document.
+// FIXME: Unused variable
 const int SCHD_STALL = -2;
 
 // TODO(max): Eliminate these limits.
@@ -154,7 +156,7 @@ public:
   // early infeasibility might get detected by this function, in which case it
   // returns false. Otherwise, returns true.
   bool InitForSchdulng(InstCount schedLngth = INVALID_VALUE,
-                       LinkedList<SchedInstruction> *fxdLst = NULL);
+                       LinkedList<SchedInstruction> *fxdLst = nullptr);
 
   // Returns the name of the instruction.
   const char *GetName() const;
@@ -177,8 +179,10 @@ public:
   InstCount GetLwrBound(DIRECTION dir) const;
 
   // Returns the number of predecessors of this instruction.
+  // FIXME: Hides a non-virtual method
   InstCount GetPrdcsrCnt() const;
   // Returns the number of successors of this instruction node.
+  // FIXME: Hides a non-virtual method
   InstCount GetScsrCnt() const;
   // Returns the number of predecessors in this instructions transitive
   // closure (i.e. total number of ancestors).
@@ -197,14 +201,14 @@ public:
   //     successor list.
   //   ltncy: the latency from the predecessor to this instruction.
   //   depType: the type of dependence between this node and the predecessor.
-  SchedInstruction *GetFrstPrdcsr(InstCount *scsrNum = NULL,
-                                  UDT_GLABEL *ltncy = NULL,
-                                  DependenceType *depType = NULL);
+  SchedInstruction *GetFrstPrdcsr(InstCount *scsrNum = nullptr,
+                                  UDT_GLABEL *ltncy = nullptr,
+                                  DependenceType *depType = nullptr);
   // Returns the next predecessor of this instruction node and moves the
   // predecessor iterator forward. Fills parameters as above.
-  SchedInstruction *GetNxtPrdcsr(InstCount *scsrNum = NULL,
-                                 UDT_GLABEL *ltncy = NULL,
-                                 DependenceType *depType = NULL);
+  SchedInstruction *GetNxtPrdcsr(InstCount *scsrNum = nullptr,
+                                 UDT_GLABEL *ltncy = nullptr,
+                                 DependenceType *depType = nullptr);
 
   // Returns the first successor of this instruction node and resets the
   // successor iterator. Writes edge properties into the parameters if
@@ -213,34 +217,35 @@ public:
   //     predecessor list.
   //   ltncy: the latency from this instruction to the successor.
   //   depType: the type of dependence between this node and the successor.
-  SchedInstruction *GetFrstScsr(InstCount *prdcsrNum = NULL,
-                                UDT_GLABEL *ltncy = NULL,
-                                DependenceType *depType = NULL);
+  SchedInstruction *GetFrstScsr(InstCount *prdcsrNum = nullptr,
+                                UDT_GLABEL *ltncy = nullptr,
+                                DependenceType *depType = nullptr);
   // Returns the next successor of this instruction node and moves the
   // successor iterator forward. Fills parameters as above.
-  SchedInstruction *GetNxtScsr(InstCount *prdcsrNum = NULL,
-                               UDT_GLABEL *ltncy = NULL,
-                               DependenceType *depType = NULL);
+  // FIXME: Unimplemented method
+  SchedInstruction *GetNxtScsr(InstCount *prdcsrNum = nullptr,
+                               UDT_GLABEL *ltncy = nullptr,
+                               DependenceType *depType = nullptr);
 
   // Returns the last successor of this instruction node and moves the
   // successor iterator to the end of the list. If prdcsrNum is provided, this
   // instruction's number (order) in the successor's predecessor list is
   // written to it.
-  SchedInstruction *GetLastScsr(InstCount *prdcsrNum = NULL);
+  SchedInstruction *GetLastScsr(InstCount *prdcsrNum = nullptr);
   // Returns the previous predecessor of this instruction node and moves the
   // predecessor iterator backward. Fills prdcsrNum as above.
-  SchedInstruction *GetPrevScsr(InstCount *prdcsrNum = NULL);
+  SchedInstruction *GetPrevScsr(InstCount *prdcsrNum = nullptr);
 
   // Returns the first predecessor or successor of this instruction node,
   // depending on the value of dir, filling in the latency from the
   // predecessor to this instruction into ltncy, if provided. Resets the
   // predecessor or successor iterator (the two iterator are independent).
-  SchedInstruction *GetFrstNghbr(DIRECTION dir, UDT_GLABEL *ltncy = NULL);
+  SchedInstruction *GetFrstNghbr(DIRECTION dir, UDT_GLABEL *ltncy = nullptr);
   // Returns the next predecessor or successor of this instruction node,
   // depending on the value of dir, filling in the latency from the
   // predecessor to this instruction into ltncy, if provided. Moves the
   // predecessor iterator forward (the two iterator are independent).
-  SchedInstruction *GetNxtNghbr(DIRECTION dir, UDT_GLABEL *ltncy = NULL);
+  SchedInstruction *GetNxtNghbr(DIRECTION dir, UDT_GLABEL *ltncy = nullptr);
   /***************************************************************************/
 
   // Sets the instruction's current forward and backward lower bounds to the
@@ -284,6 +289,7 @@ public:
 
   // Notifies this instruction that one of its successors has been scheduled.
   // Returns true if that was the last successor to schedule.
+  // FIXME: Unused method
   bool ScsrSchduld();
 
   // Schedules the instruction to a given cycle and clot number.
@@ -292,6 +298,8 @@ public:
   void UnSchedule();
 
   // Sets the instruction type to a given value.
+
+  // FIXME: Unused method
   void SetInstType(InstType type);
   // Returns the type of the instruction.
   InstType GetInstType() const;
@@ -303,7 +311,7 @@ public:
   // Returns whether the instruction has been scheduled. If the cycle argument
   // is provided, it is filled with the cycle to which this instruction has
   // been scheduled.
-  bool IsSchduld(InstCount *cycle = NULL) const;
+  bool IsSchduld(InstCount *cycle = nullptr) const;
 
   // Returns the cycle to which this instruction has been scheduled.
   InstCount GetSchedCycle() const;
@@ -316,6 +324,7 @@ public:
   InstCount GetCrntReleaseTime() const;
   // Returns the relaxed cycle number for this instruction.
   // TODO(ghassan): Elaborate.
+  // FIXME: Unused method
   InstCount GetRlxdCycle() const;
   // Sets the relaxed cycle number for this instruction.
   // TODO(ghassan): Elaborate.
@@ -331,6 +340,7 @@ public:
   // is added to the given list to be used for efficient untightening. This
   // function returns with false as soon as infeasiblity (w.r.t the given
   // schedule length) is detected, otherwise it returns true.
+  // FIXME: Unused method
   bool TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                       LinkedList<SchedInstruction> *tightndLst,
                       LinkedList<SchedInstruction> *fxdLst, bool enforce);
@@ -402,6 +412,7 @@ public:
   // Add a register usage to this instruction node.
   void AddUse(Register *reg);
   // Returns whether this instruction defines the specified register.
+  // FIXME: Unused method
   bool FindDef(Register *reg) const;
   // Returns whether this instruction uses the specified register.
   bool FindUse(Register *reg) const;
@@ -411,18 +422,20 @@ public:
   // Retrieves the list of registers used by this node. The array is put
   // into uses and the number of elements is returned.
   int16_t GetUses(Register **&uses);
-
+  // FIXME: Unused method
   int16_t GetDefCnt() { return defCnt_; }
   int16_t GetUseCnt() { return useCnt_; }
 
   // Return the adjusted use count. The number of uses minus live-out uses.
   int16_t GetAdjustedUseCnt() { return adjustedUseCnt_; }
   // Computer the adjusted use count. Update "adjustedUseCnt_".
+  // FIXME: Unimplemented method
   void ComputeAdjustedUseCnt(SchedInstruction *inst);
 
   int16_t CmputLastUseCnt();
   int16_t GetLastUseCnt() { return lastUseCnt_; }
 
+  // FIXME: Unused method
   InstType GetCrtclPathFrmRoot() { return crtclPathFrmRoot_; }
 
   friend class SchedRange;
@@ -601,7 +614,7 @@ protected:
 class SchedRange {
 public:
   // Creates a scheduling range for a given instruction.
-  SchedRange(SchedInstruction *inst);
+  explicit SchedRange(SchedInstruction *inst);
 
   // Sets the range's boudns to the given values. If the range is then
   // "fixed" with respect to schedLngth, adds its instruction to fxdLst.

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -11,6 +11,7 @@
 
 using namespace llvm::opt_sched;
 
+// FIXME: Unused function
 static void PrintInstruction(SchedInstruction *inst);
 void PrintSchedule(InstSchedule *schedule);
 
@@ -73,9 +74,9 @@ ACOScheduler::~ACOScheduler() {
 // from empty schedule to schedule only containing instruction 10
 pheremone_t &ACOScheduler::Pheremone(SchedInstruction *from,
                                      SchedInstruction *to) {
-  assert(to != NULL);
+  assert(to != nullptr);
   int fromNum = -1;
-  if (from != NULL)
+  if (from != nullptr)
     fromNum = from->GetNum();
   return Pheremone(fromNum, to->GetNum());
 }
@@ -92,9 +93,10 @@ double ACOScheduler::Score(SchedInstruction *from, Choice choice) {
          pow(choice.heuristic, heuristicImportance_);
 }
 
-std::vector<double> ACOScheduler::scores(std::vector<Choice> ready,
+// FIXME: Unused method
+std::vector<double> ACOScheduler::scores(const std::vector<Choice> &ready,
                                          SchedInstruction *last) {
-  std::vector<double> s;
+  std::vector<double> s(ready.size());
   for (auto choice : ready)
     s.push_back(Score(last, choice));
   return s;
@@ -113,7 +115,7 @@ SchedInstruction *ACOScheduler::SelectInstruction(std::vector<Choice> ready,
     if (print_aco_trace)
       std::cerr << "choose_best, use fixed bais: " << use_fixed_bias << "\n";
     pheremone_t max = -1;
-    Choice maxChoice;
+    Choice maxChoice{};
     for (auto choice : ready) {
       if (Score(lastInst, choice) > max) {
         max = Score(lastInst, choice);
@@ -127,27 +129,27 @@ SchedInstruction *ACOScheduler::SelectInstruction(std::vector<Choice> ready,
     int POPULATION_SIZE = ready.size();
     int r_pos = (int)(RandDouble(0, 1) * POPULATION_SIZE);
     int s_pos = (int)(RandDouble(0, 1) * POPULATION_SIZE);
-    //    int t_pos = (int) (RandDouble(0, 1) *POPULATION_SIZE);
+    //        int t_pos = (int) (RandDouble(0, 1) *POPULATION_SIZE);
     Choice r = ready[r_pos];
     Choice s = ready[s_pos];
-    //    Choice t = ready[t_pos];
+    //        Choice t = ready[t_pos];
     if (print_aco_trace) {
       std::cerr << "tournament Start \n";
       std::cerr << "array_size:" << POPULATION_SIZE << "\n";
       std::cerr << "r:\t" << r_pos << "\n";
       std::cerr << "s:\t" << s_pos << "\n";
-      //        std::cerr<<"t:\t"<<t_pos<<"\n";
+      //            std::cerr<<"t:\t"<<t_pos<<"\n";
 
       std::cerr << "Score r" << Score(lastInst, r) << "\n";
       std::cerr << "Score s" << Score(lastInst, s) << "\n";
-      //         std::cerr<<"Score t"<<Score(lastInst, t)<<"\n";
+      //            std::cerr<<"Score t"<<Score(lastInst, t)<<"\n";
     }
     if (Score(lastInst, r) >=
         Score(lastInst, s)) //&& Score(lastInst, r) >= Score(lastInst, t))
       return r.inst;
-    //     else if (Score(lastInst, s) >= Score(lastInst, r) && Score(lastInst,
-    //     s) >= Score(lastInst, t))
-    //         return s.inst;
+    //        else if (Score(lastInst, s) >= Score(lastInst, r) &&
+    //        Score(lastInst, s) >= Score(lastInst, t))
+    //            return s.inst;
     else
       return s.inst;
   }
@@ -166,8 +168,8 @@ SchedInstruction *ACOScheduler::SelectInstruction(std::vector<Choice> ready,
 }
 
 InstSchedule *ACOScheduler::FindOneSchedule() {
-  SchedInstruction *lastInst = NULL;
-  InstSchedule *schedule = new InstSchedule(machMdl_, dataDepGraph_, true);
+  SchedInstruction *lastInst = nullptr;
+  auto *schedule = new InstSchedule(machMdl_, dataDepGraph_, true);
   InstCount maxPriority = rdyLst_->MaxPriority();
   if (maxPriority == 0)
     maxPriority = 1; // divide by 0 is bad
@@ -180,9 +182,9 @@ InstSchedule *ACOScheduler::FindOneSchedule() {
     std::vector<Choice> ready;
     unsigned long heuristic;
     SchedInstruction *inst = rdyLst_->GetNextPriorityInst(heuristic);
-    while (inst != NULL) {
+    while (inst != nullptr) {
       if (ChkInstLglty_(inst)) {
-        Choice c;
+        Choice c{};
         c.inst = inst;
         c.heuristic = (double)heuristic / maxPriority;
         ready.push_back(c);
@@ -201,10 +203,10 @@ InstSchedule *ACOScheduler::FindOneSchedule() {
     Logger::Info(stream.str().c_str());
     */
 
-    inst = NULL;
+    inst = nullptr;
     if (!ready.empty())
       inst = SelectInstruction(ready, lastInst);
-    if (inst != NULL) {
+    if (inst != nullptr) {
 #ifdef USE_ACS
       // local pheremone decay
       pheremone_t *pheremone = &Pheremone(lastInst, inst);
@@ -215,7 +217,7 @@ InstSchedule *ACOScheduler::FindOneSchedule() {
 
     // boilerplate, mostly copied from ListScheduler, try not to touch it
     InstCount instNum;
-    if (inst == NULL) {
+    if (inst == nullptr) {
       instNum = SCHD_STALL;
     } else {
       instNum = inst->GetNum();
@@ -225,7 +227,7 @@ InstSchedule *ACOScheduler::FindOneSchedule() {
       DoRsrvSlots_(inst);
       // this is annoying
       SchedInstruction *blah = rdyLst_->GetNextPriorityInst();
-      while (blah != NULL && blah != inst) {
+      while (blah != nullptr && blah != inst) {
         blah = rdyLst_->GetNextPriorityInst();
       }
       if (blah == inst)
@@ -264,18 +266,18 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
     pheremone_[i] = initialValue_;
   std::cerr << "initialValue_" << initialValue_ << std::endl;
 
-  InstSchedule *bestSchedule = NULL;
+  InstSchedule *bestSchedule = nullptr;
   Config &schedIni = SchedulerOptions::getInstance();
   int noImprovementMax = schedIni.GetInt("ACO_STOP_ITERATIONS");
   int noImprovement = 0; // how many iterations with no improvement
   int iterations = 0;
   while (true) {
-    InstSchedule *iterationBest = NULL;
+    InstSchedule *iterationBest = nullptr;
     for (int i = 0; i < ants_per_iteration; i++) {
       InstSchedule *schedule = FindOneSchedule();
       if (print_aco_trace)
         PrintSchedule(schedule);
-      if (iterationBest == NULL ||
+      if (iterationBest == nullptr ||
           schedule->GetCost() < iterationBest->GetCost()) {
         delete iterationBest;
         iterationBest = schedule;
@@ -289,7 +291,9 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
     /* PrintSchedule(iterationBest); */
     /* std::cout << iterationBest->GetCost() << std::endl; */
     // TODO DRY
-    if (bestSchedule == NULL ||
+    // FIXME: iterationBest and bestSchedule may be null
+    // TODO: Use smart pointers
+    if (bestSchedule == nullptr ||
         iterationBest->GetCost() < bestSchedule->GetCost()) {
       delete bestSchedule;
       bestSchedule = iterationBest;
@@ -323,7 +327,7 @@ void ACOScheduler::UpdatePheremone(InstSchedule *schedule) {
   InstCount instNum, cycleNum, slotNum;
   instNum = schedule->GetFrstInst(cycleNum, slotNum);
 
-  SchedInstruction *lastInst = NULL;
+  SchedInstruction *lastInst = nullptr;
   while (instNum != INVALID_VALUE) {
     SchedInstruction *inst = dataDepGraph_->GetInstByIndx(instNum);
 
@@ -357,7 +361,7 @@ void ACOScheduler::UpdatePheremone(InstSchedule *schedule) {
 // copied from Enumerator
 inline void ACOScheduler::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
   InstCount prevCycleNum = cycleNum - 1;
-  LinkedList<SchedInstruction> *lst1 = NULL;
+  LinkedList<SchedInstruction> *lst1 = nullptr;
   LinkedList<SchedInstruction> *lst2 = frstRdyLstPerCycle_[cycleNum];
 
   if (slotNum == 0 && prevCycleNum >= 0) {
@@ -367,14 +371,14 @@ inline void ACOScheduler::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
     // the very last slot of that cycle [GOS 9.8.02].
     lst1 = frstRdyLstPerCycle_[prevCycleNum];
 
-    if (lst1 != NULL) {
+    if (lst1 != nullptr) {
       rdyLst_->AddList(lst1);
       lst1->Reset();
       CleanupCycle_(prevCycleNum);
     }
   }
 
-  if (lst2 != NULL) {
+  if (lst2 != nullptr) {
     rdyLst_->AddList(lst2);
     lst2->Reset();
   }
@@ -391,6 +395,7 @@ void ACOScheduler::PrintPheremone() {
   std::cerr << std::endl;
 }
 
+// FIXME: Unused function
 static void PrintInstruction(SchedInstruction *inst) {
   std::cerr << std::setw(2) << inst->GetNum() << " ";
   std::cerr << std::setw(20) << std::left << inst->GetOpCode();

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -27,6 +27,8 @@ using namespace llvm::opt_sched;
 // The denominator used when calculating cost weight.
 static const int COST_WGHT_BASE = 10;
 
+// FIXME: Constructor does not initialize fields crntStepNum_, peakSpillCost_,
+// totSpillCost_, slilSpillCost_
 BBWithSpill::BBWithSpill(const OptSchedTarget *OST_, DataDepGraph *dataDepGraph,
                          long rgnNum, int16_t sigHashSize, LB_ALG lbAlg,
                          SchedPriorities hurstcPrirts,
@@ -40,7 +42,7 @@ BBWithSpill::BBWithSpill(const OptSchedTarget *OST_, DataDepGraph *dataDepGraph,
                   HeurSchedType),
       OST(OST_) {
   costLwrBound_ = 0;
-  enumrtr_ = NULL;
+  enumrtr_ = nullptr;
   optmlSpillCost_ = INVALID_VALUE;
 
   crntCycleNum_ = INVALID_VALUE;
@@ -73,9 +75,8 @@ BBWithSpill::BBWithSpill(const OptSchedTarget *OST_, DataDepGraph *dataDepGraph,
 /****************************************************************************/
 
 BBWithSpill::~BBWithSpill() {
-  if (enumrtr_ != NULL) {
-    delete enumrtr_;
-  }
+
+  delete enumrtr_;
 
   delete[] liveRegs_;
   delete[] livePhysRegs_;
@@ -236,7 +237,7 @@ static InstCount ComputeSLILStaticLowerBound(int64_t regTypeCnt_,
       Register *reg = usedRegisters[j];
       assert(reg->GetDefList().size() == 1 &&
              "Number of defs for register is not 1!");
-      usedInsts.push_back(std::make_pair(*(reg->GetDefList().begin()), reg));
+      usedInsts.emplace_back(*(reg->GetDefList().begin()), reg);
     }
 
 #if defined(IS_DEBUG_SLIL_COMMON_USE_LB)
@@ -465,7 +466,7 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
     regNum = use->GetNum();
     physRegNum = use->GetPhysicalNumber();
 
-    if (use->IsLive() == false)
+    if (!use->IsLive())
       Logger::Fatal("Reg %d of type %d is used without being defined", regNum,
                     regType);
 
@@ -476,7 +477,7 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
 
     use->AddCrntUse();
 
-    if (use->IsLive() == false) {
+    if (!use->IsLive()) {
       // (Chris): The SLIL calculation below the def and use for-loops doesn't
       // consider the last use of a register. Thus, an additional increment must
       // happen here.
@@ -703,7 +704,7 @@ void BBWithSpill::UpdateSpillInfoForUnSchdul_(SchedInstruction *inst) {
     use->DelCrntUse();
     assert(use->IsLive());
 
-    if (isLive == false) {
+    if (!isLive) {
       // (Chris): Since this was the last use, the above SLIL calculation didn't
       // take this instruction into account.
       if (spillCostFunc_ == SCF_SLIL) {
@@ -736,7 +737,7 @@ void BBWithSpill::UpdateSpillInfoForUnSchdul_(SchedInstruction *inst) {
   crntStepNum_--;
 
 #ifdef IS_DEBUG_REG_PRESSURE
-// Logger::Info("Spill cost at step  %d = %d", crntStepNum_, newSpillCost);
+  // Logger::Info("Spill cost at step  %d = %d", crntStepNum_, newSpillCost);
 #endif
 }
 /*****************************************************************************/
@@ -745,9 +746,9 @@ void BBWithSpill::SchdulInst(SchedInstruction *inst, InstCount cycleNum,
                              InstCount slotNum, bool trackCnflcts) {
   crntCycleNum_ = cycleNum;
   crntSlotNum_ = slotNum;
-  if (inst == NULL)
+  if (inst == nullptr)
     return;
-  assert(inst != NULL);
+  assert(inst != nullptr);
   UpdateSpillInfoForSchdul_(inst, trackCnflcts);
 }
 /*****************************************************************************/
@@ -762,7 +763,7 @@ void BBWithSpill::UnschdulInst(SchedInstruction *inst, InstCount cycleNum,
     crntSlotNum_ = slotNum - 1;
   }
 
-  if (inst == NULL) {
+  if (inst == nullptr) {
     return;
   }
 
@@ -799,7 +800,7 @@ Enumerator *BBWithSpill::AllocEnumrtr_(Milliseconds timeout) {
   enumrtr_ = new LengthCostEnumerator(
       dataDepGraph_, machMdl_, schedUprBound_, sigHashSize_, enumPrirts_,
       prune_, SchedForRPOnly_, enblStallEnum, timeout, spillCostFunc_, 0, NULL);
-  if (enumrtr_ == NULL)
+  if (enumrtr_ == nullptr)
     Logger::Fatal("Out of memory.");
 
   return enumrtr_;

--- a/lib/Scheduler/config.cpp
+++ b/lib/Scheduler/config.cpp
@@ -17,7 +17,7 @@ template <class T> T Convert(const string &value) {
 
 template <class T> list<T> Split(const string &value) {
   list<T> values;
-  if (value == "")
+  if (value.empty())
     return values;
 
   istringstream ss(value);
@@ -44,23 +44,23 @@ void Config::Load(std::istream &file) {
   while (!file.eof()) {
     string name, value, comment;
     file >> name;
-    while (!file.fail() && name.size() && name[0] == '#') {
+    while (!file.fail() && !name.empty() && name[0] == '#') {
       std::getline(file, comment);
       file >> name;
     }
     file >> value;
-    while (!file.fail() && value.size() && value[0] == '#') {
+    while (!file.fail() && !value.empty() && value[0] == '#') {
       std::getline(file, comment);
       file >> value;
     }
-    if (file.fail() || name == "" || value == "")
+    if (file.fail() || name.empty() || value.empty())
       break;
     settings[name] = value;
   }
 }
 
 string Config::GetString(const string &name) const {
-  std::map<string, string>::const_iterator it = settings.find(name);
+  auto it = settings.find(name);
   if (it == settings.end()) {
     Logger::Fatal("No value found for setting %s.", name.c_str());
     return "";
@@ -70,7 +70,7 @@ string Config::GetString(const string &name) const {
 }
 
 string Config::GetString(const string &name, const string &default_) const {
-  std::map<string, string>::const_iterator it = settings.find(name);
+  auto it = settings.find(name);
   if (it == settings.end()) {
     return default_;
   } else {
@@ -94,6 +94,7 @@ float Config::GetFloat(const string &name) const {
   return Convert<float>(GetString(name));
 }
 
+// FIXME: Unused method
 float Config::GetFloat(const string &name, float default_) const {
   if (settings.find(name) == settings.end()) {
     return default_;
@@ -125,7 +126,7 @@ bool Config::GetBool(const string &name, bool default_) const {
 list<string> Config::GetStringList(const string &name) const {
   list<string> values;
   string line = GetString(name, "");
-  if (line == "")
+  if (line.empty())
     return values;
 
   istringstream ss(line);
@@ -138,10 +139,12 @@ list<string> Config::GetStringList(const string &name) const {
   return values;
 }
 
+// FIXME: Unused method
 list<int64_t> Config::GetIntList(const string &name) const {
   return Split<int64_t>(GetString(name, ""));
 }
 
+// FIXME: Unused method
 list<float> Config::GetFloatList(const string &name) const {
   return Split<float>(GetString(name, ""));
 }

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -4,6 +4,9 @@
 
 using namespace llvm::opt_sched;
 
+// FIXME: Constructor does not initialize: issuType_, prdcsrCnt_, scsrCnt_,
+// crntSchedSlot_, defs_, uses_,
+// FIXME: adjustedUseCnt_, lastUseCnt_
 SchedInstruction::SchedInstruction(InstCount num, const string &name,
                                    InstType instType, const string &opCode,
                                    InstCount maxInstCnt, int nodeID,
@@ -23,24 +26,24 @@ SchedInstruction::SchedInstruction(InstCount num, const string &name,
   crtclPathFrmRoot_ = INVALID_VALUE;
   crtclPathFrmLeaf_ = INVALID_VALUE;
 
-  ltncyPerPrdcsr_ = NULL;
+  ltncyPerPrdcsr_ = nullptr;
   memAllocd_ = false;
-  sortedPrdcsrLst_ = NULL;
-  sortedScsrLst_ = NULL;
+  sortedPrdcsrLst_ = nullptr;
+  sortedScsrLst_ = nullptr;
 
-  crtclPathFrmRcrsvScsr_ = NULL;
-  crtclPathFrmRcrsvPrdcsr_ = NULL;
+  crtclPathFrmRcrsvScsr_ = nullptr;
+  crtclPathFrmRcrsvPrdcsr_ = nullptr;
 
   // Dynamic data that changes during scheduling.
   ready_ = false;
-  rdyCyclePerPrdcsr_ = NULL;
+  rdyCyclePerPrdcsr_ = nullptr;
   minRdyCycle_ = INVALID_VALUE;
-  prevMinRdyCyclePerPrdcsr_ = NULL;
+  prevMinRdyCyclePerPrdcsr_ = nullptr;
   unschduldPrdcsrCnt_ = 0;
   unschduldScsrCnt_ = 0;
 
   crntRange_ = new SchedRange(this);
-  if (crntRange_ == NULL)
+  if (crntRange_ == nullptr)
     Logger::Fatal("Out of memory.");
 
   crntSchedCycle_ = SCHD_UNSCHDULD;
@@ -165,13 +168,13 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
   prevMinRdyCyclePerPrdcsr_ = new InstCount[prdcsrCnt_];
   sortedPrdcsrLst_ = new PriorityList<SchedInstruction>;
 
-  if (rdyCyclePerPrdcsr_ == NULL || ltncyPerPrdcsr_ == NULL ||
-      prevMinRdyCyclePerPrdcsr_ == NULL || sortedPrdcsrLst_ == NULL) {
+  if (rdyCyclePerPrdcsr_ == nullptr || ltncyPerPrdcsr_ == nullptr ||
+      prevMinRdyCyclePerPrdcsr_ == nullptr || sortedPrdcsrLst_ == nullptr) {
     Logger::Fatal("Out of memory.");
   }
 
   InstCount predecessorIndex = 0;
-  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != NULL;
+  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != nullptr;
        edge = prdcsrLst_->GetNxtElmnt()) {
     ltncyPerPrdcsr_[predecessorIndex++] = edge->label;
     sortedPrdcsrLst_->InsrtElmnt((SchedInstruction *)edge->GetOtherNode(this),
@@ -180,7 +183,7 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 
   if (isCP_FromScsr) {
     crtclPathFrmRcrsvScsr_ = new InstCount[instCnt];
-    if (crtclPathFrmRcrsvScsr_ == NULL)
+    if (crtclPathFrmRcrsvScsr_ == nullptr)
       Logger::Fatal("Out of memory.");
 
     for (InstCount i = 0; i < instCnt; i++) {
@@ -192,7 +195,7 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 
   if (isCP_FromPrdcsr) {
     crtclPathFrmRcrsvPrdcsr_ = new InstCount[instCnt];
-    if (crtclPathFrmRcrsvPrdcsr_ == NULL)
+    if (crtclPathFrmRcrsvPrdcsr_ == nullptr)
       Logger::Fatal("Out of memory.");
 
     for (InstCount i = 0; i < instCnt; i++) {
@@ -207,21 +210,13 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 
 void SchedInstruction::DeAllocMem_() {
   assert(memAllocd_);
-
-  if (rdyCyclePerPrdcsr_ != NULL)
-    delete[] rdyCyclePerPrdcsr_;
-  if (prevMinRdyCyclePerPrdcsr_ != NULL)
-    delete[] prevMinRdyCyclePerPrdcsr_;
-  if (ltncyPerPrdcsr_ != NULL)
-    delete[] ltncyPerPrdcsr_;
-  if (sortedPrdcsrLst_ != NULL)
-    delete sortedPrdcsrLst_;
-  if (sortedScsrLst_ != NULL)
-    delete sortedScsrLst_;
-  if (crtclPathFrmRcrsvScsr_ != NULL)
-    delete[] crtclPathFrmRcrsvScsr_;
-  if (crtclPathFrmRcrsvPrdcsr_ != NULL)
-    delete[] crtclPathFrmRcrsvPrdcsr_;
+  delete[] rdyCyclePerPrdcsr_;
+  delete[] prevMinRdyCyclePerPrdcsr_;
+  delete[] ltncyPerPrdcsr_;
+  delete sortedPrdcsrLst_;
+  delete sortedScsrLst_;
+  delete[] crtclPathFrmRcrsvScsr_;
+  delete[] crtclPathFrmRcrsvPrdcsr_;
 
   memAllocd_ = false;
 }
@@ -235,13 +230,13 @@ InstCount SchedInstruction::CmputCrtclPath_(DIRECTION dir,
   InstCount crtclPath = 0;
   LinkedList<GraphEdge> *nghbrLst = (dir == DIR_FRWRD) ? prdcsrLst_ : scsrLst_;
 
-  for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
+  for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != nullptr;
        edg = nghbrLst->GetNxtElmnt()) {
     UDT_GLABEL edgLbl = edg->label;
-    SchedInstruction *nghbr = (SchedInstruction *)(edg->GetOtherNode(this));
+    auto *nghbr = (SchedInstruction *)(edg->GetOtherNode(this));
 
     InstCount nghbrCrtclPath;
-    if (ref == NULL) {
+    if (ref == nullptr) {
       nghbrCrtclPath = nghbr->GetCrtclPath(dir);
     } else {
       // When computing relative critical paths, we only need to consider
@@ -274,7 +269,7 @@ void SchedInstruction::AddDef(Register *reg) {
   // %d",
   // num_, reg->GetNum(), reg->GetType(), reg->GetPhysicalNumber(),
   // reg->GetUseCnt());
-  assert(reg != NULL);
+  assert(reg != nullptr);
   defs_[defCnt_++] = reg;
 }
 
@@ -286,12 +281,12 @@ void SchedInstruction::AddUse(Register *reg) {
   // Logger::Info("Inst %d uses reg %d of type %d and physNum %d and useCnt %d",
   // num_, reg->GetNum(), reg->GetType(), reg->GetPhysicalNumber(),
   // reg->GetUseCnt());
-  assert(reg != NULL);
+  assert(reg != nullptr);
   uses_[useCnt_++] = reg;
 }
 
 bool SchedInstruction::FindDef(Register *reg) const {
-  assert(reg != NULL);
+  assert(reg != nullptr);
 
   for (int i = 0; i < defCnt_; i++) {
     if (defs_[i] == reg)
@@ -302,7 +297,7 @@ bool SchedInstruction::FindDef(Register *reg) const {
 }
 
 bool SchedInstruction::FindUse(Register *reg) const {
-  assert(reg != NULL);
+  assert(reg != nullptr);
 
   for (int i = 0; i < useCnt_; i++) {
     if (uses_[i] == reg)
@@ -346,6 +341,7 @@ const char *SchedInstruction::GetOpCode() const { return opCode_.c_str(); }
 
 int SchedInstruction::GetNodeID() const { return nodeID_; }
 
+// FIXME: Unused method
 void SchedInstruction::SetNodeID(int nodeID) { nodeID_ = nodeID; }
 
 int SchedInstruction::GetLtncySum() const { return GetScsrLblSum(); }
@@ -361,13 +357,13 @@ InstCount SchedInstruction::GetScsrCnt() const {
 }
 
 InstCount SchedInstruction::GetRcrsvPrdcsrCnt() const {
-  assert(rcrsvPrdcsrLst_ != NULL);
+  assert(rcrsvPrdcsrLst_ != nullptr);
   assert(rcrsvPrdcsrLst_->GetElmntCnt() >= prdcsrCnt_);
   return rcrsvPrdcsrLst_->GetElmntCnt();
 }
 
 InstCount SchedInstruction::GetRcrsvScsrCnt() const {
-  assert(rcrsvScsrLst_ != NULL);
+  assert(rcrsvScsrLst_ != nullptr);
   assert(rcrsvScsrLst_->GetElmntCnt() >= scsrCnt_);
   return rcrsvScsrLst_->GetElmntCnt();
 }
@@ -377,7 +373,7 @@ SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
                                                   DependenceType *depType) {
   GraphEdge *edge = prdcsrLst_->GetFrstElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (scsrNum)
     *scsrNum = edge->succOrder;
   if (ltncy)
@@ -392,7 +388,7 @@ SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
                                                  DependenceType *depType) {
   GraphEdge *edge = prdcsrLst_->GetNxtElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (scsrNum)
     *scsrNum = edge->succOrder;
   if (ltncy)
@@ -407,7 +403,7 @@ SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
                                                 DependenceType *depType) {
   GraphEdge *edge = scsrLst_->GetFrstElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (prdcsrNum)
     *prdcsrNum = edge->predOrder;
   if (ltncy)
@@ -422,7 +418,7 @@ SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
                                                DependenceType *depType) {
   GraphEdge *edge = scsrLst_->GetNxtElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (prdcsrNum)
     *prdcsrNum = edge->predOrder;
   if (ltncy)
@@ -435,7 +431,7 @@ SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
 SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
   GraphEdge *edge = scsrLst_->GetLastElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (prdcsrNum)
     *prdcsrNum = edge->predOrder;
   return (SchedInstruction *)(edge->to);
@@ -444,7 +440,7 @@ SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
 SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
   GraphEdge *edge = scsrLst_->GetPrevElmnt();
   if (!edge)
-    return NULL;
+    return nullptr;
   if (prdcsrNum)
     *prdcsrNum = edge->predOrder;
   return (SchedInstruction *)(edge->to);
@@ -453,8 +449,8 @@ SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
 SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
                                                  UDT_GLABEL *ltncy) {
   GraphEdge *edge = (dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_)->GetFrstElmnt();
-  if (edge == NULL)
-    return NULL;
+  if (edge == nullptr)
+    return nullptr;
   if (ltncy)
     *ltncy = edge->label;
   return (SchedInstruction *)((dir == DIR_FRWRD) ? edge->to : edge->from);
@@ -463,8 +459,8 @@ SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
 SchedInstruction *SchedInstruction::GetNxtNghbr(DIRECTION dir,
                                                 UDT_GLABEL *ltncy) {
   GraphEdge *edge = (dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_)->GetNxtElmnt();
-  if (edge == NULL)
-    return NULL;
+  if (edge == nullptr)
+    return nullptr;
   if (ltncy)
     *ltncy = edge->label;
   return (SchedInstruction *)((dir == DIR_FRWRD) ? edge->to : edge->from);
@@ -577,11 +573,13 @@ bool SchedInstruction::PrdcsrUnSchduld(InstCount prdcsrNum,
   return (unschduldPrdcsrCnt_ == 1);
 }
 
+// FIXME: Unused method
 bool SchedInstruction::ScsrSchduld() {
   unschduldScsrCnt_--;
   return unschduldScsrCnt_ == 0;
 }
 
+// FIXME: Unused method
 void SchedInstruction::SetInstType(InstType type) { instType_ = type; }
 
 void SchedInstruction::SetIssueType(IssueType type) { issuType_ = type; }
@@ -608,6 +606,7 @@ InstCount SchedInstruction::GetCrntReleaseTime() const {
   return IsSchduld() ? crntSchedCycle_ : GetCrntLwrBound(DIR_FRWRD);
 }
 
+// FIXME: Unused method
 InstCount SchedInstruction::GetRlxdCycle() const {
   return IsSchduld() ? crntSchedCycle_ : crntRlxdCycle_;
 }
@@ -659,6 +658,7 @@ bool SchedInstruction::IsFxd() const { return crntRange_->IsFxd(); }
 
 InstCount SchedInstruction::GetPreFxdCycle() const { return preFxdCycle_; }
 
+// FIXME: Unused method
 bool SchedInstruction::TightnLwrBound(DIRECTION dir, InstCount newLwrBound,
                                       LinkedList<SchedInstruction> *tightndLst,
                                       LinkedList<SchedInstruction> *fxdLst,
@@ -680,10 +680,10 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
     return false;
 
   LinkedList<GraphEdge> *nghbrLst = scsrLst_;
-  for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
+  for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != nullptr;
        edg = nghbrLst->GetNxtElmnt()) {
     UDT_GLABEL edgLbl = edg->label;
-    SchedInstruction *nghbr = (SchedInstruction *)(edg->GetOtherNode(this));
+    auto *nghbr = (SchedInstruction *)(edg->GetOtherNode(this));
     InstCount nghbrNewLwrBound = cycle + edgLbl;
 
     // If this neighbor will get delayed by scheduling this instruction in the
@@ -717,7 +717,7 @@ InstCount SchedInstruction::GetFileSchedCycle() const {
 void SchedInstruction::SetScsrNums_() {
   InstCount scsrNum = 0;
 
-  for (GraphEdge *edge = scsrLst_->GetFrstElmnt(); edge != NULL;
+  for (GraphEdge *edge = scsrLst_->GetFrstElmnt(); edge != nullptr;
        edge = scsrLst_->GetNxtElmnt()) {
     edge->succOrder = scsrNum++;
   }
@@ -728,7 +728,7 @@ void SchedInstruction::SetScsrNums_() {
 void SchedInstruction::SetPrdcsrNums_() {
   InstCount prdcsrNum = 0;
 
-  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != NULL;
+  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != nullptr;
        edge = prdcsrLst_->GetNxtElmnt()) {
     edge->predOrder = prdcsrNum++;
   }
@@ -753,6 +753,9 @@ int16_t SchedInstruction::CmputLastUseCnt() {
  * SchedRange                                                                 *
  ******************************************************************************/
 
+// FIXME: Constructor does not initialize: prevFrwrdLwrBound_,
+// prevBkwrdLwrBound_, isFrwdTightnd_, isBkwrdTightnd_,
+// FIXME: isFxd_
 SchedRange::SchedRange(SchedInstruction *inst) {
   InitVars_();
   inst_ = inst;
@@ -830,7 +833,7 @@ bool SchedRange::TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newBound,
     if (!fsbl && !enforce)
       return false;
 
-    for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
+    for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != nullptr;
          edg = nghbrLst->GetNxtElmnt()) {
       UDT_GLABEL edgLbl = edg->label;
       SchedInstruction *nghbr = (SchedInstruction *)(edg->GetOtherNode(inst_));
@@ -881,7 +884,7 @@ bool SchedRange::SetBounds(InstCount frwrdLwrBound, InstCount bkwrdLwrBound,
 
   if (GetLwrBoundSum_() == lastCycle_) {
     isFxd_ = true;
-    assert(fxdLst != NULL);
+    assert(fxdLst != nullptr);
     fxdLst->InsrtElmnt(inst_);
   }
 
@@ -965,6 +968,7 @@ void SchedRange::SetLwrBound(DIRECTION dir, InstCount bound) {
   isTightnd = false;
 }
 
+// FIXME: Unused method
 bool SchedRange::IsTightnd(DIRECTION dir) const {
   return (dir == DIR_FRWRD) ? isFrwrdTightnd_ : isBkwrdTightnd_;
 }

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include <algorithm>
 #include <memory>
 #include <utility>
@@ -40,8 +42,8 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   bestSchedLngth_ = 0;
   hurstcCost_ = 0;
   hurstcSchedLngth_ = 0;
-  enumCrntSched_ = NULL;
-  enumBestSched_ = NULL;
+  enumCrntSched_ = nullptr;
+  enumBestSched_ = nullptr;
 
   schedLwrBound_ = 0;
   schedUprBound_ = INVALID_VALUE;
@@ -63,7 +65,7 @@ void SchedRegion::UseFileBounds_() {
 InstSchedule *SchedRegion::AllocNewSched_() {
   InstSchedule *newSched =
       new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-  if (newSched == NULL)
+  if (newSched == nullptr)
     Logger::Fatal("Out of memory.");
   return newSched;
 }
@@ -78,16 +80,16 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     InstCount &hurstcSchedLngth, InstSchedule *&bestSched, bool filterByPerp,
     const BLOCKS_TO_KEEP blocksToKeep) {
   ConstrainedScheduler *lstSchdulr;
-  InstSchedule *lstSched = NULL;
+  InstSchedule *lstSched = nullptr;
   FUNC_RESULT rslt = RES_SUCCESS;
   Milliseconds hurstcTime = 0;
   Milliseconds boundTime = 0;
   Milliseconds enumTime = 0;
   Milliseconds vrfyTime = 0;
 
-  enumCrntSched_ = NULL;
-  enumBestSched_ = NULL;
-  bestSched = bestSched_ = NULL;
+  enumCrntSched_ = nullptr;
+  enumBestSched_ = nullptr;
+  bestSched = bestSched_ = nullptr;
 
   Logger::Info("---------------------------------------------------------------"
                "------------");
@@ -128,7 +130,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   schedLwrBound_ = dataDepGraph_->GetSchedLwrBound();
   Milliseconds hurstcStart = Utilities::GetProcessorTime();
   lstSched = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-  if (lstSched == NULL)
+  if (lstSched == nullptr)
     Logger::Fatal("Out of memory.");
 
   lstSchdulr = AllocHeuristicScheduler_();
@@ -239,7 +241,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     }
   }
 #endif
-  if (EnableEnum_() == false) {
+  if (!EnableEnum_()) {
     delete lstSchdulr;
     return RES_FAIL;
   }
@@ -251,10 +253,10 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   Logger::Info("Sched LB = %d, Sched UB = %d", schedLwrBound_, schedUprBound_);
 #endif
 
-  if (isLstOptml == false) {
+  if (!isLstOptml) {
     dataDepGraph_->SetHard(true);
     rslt = Optimize_(enumStart, rgnTimeout, lngthTimeout);
-    Milliseconds enumTime = Utilities::GetProcessorTime() - enumStart;
+    enumTime = Utilities::GetProcessorTime() - enumStart;
 
     if (hurstcTime > 0) {
       enumTime /= hurstcTime;
@@ -262,7 +264,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     }
 
     if (bestCost_ < hurstcCost_) {
-      assert(enumBestSched_ != NULL);
+      assert(enumBestSched_ != nullptr);
       bestSched = bestSched_ = enumBestSched_;
 #ifdef IS_DEBUG_PRINT_SCHEDS
       enumBestSched_->Print(Logger::GetLogStream(), "Optimal");
@@ -303,7 +305,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     //#endif
   }
 
-  enumTime = Utilities::GetProcessorTime() - enumStart;
+  // FIXME: Unused expression result - is this supposed to do something? Should
+  // the result be assigned?
+  Utilities::GetProcessorTime() - enumStart;
   stats::enumerationTime.Record(enumTime);
 
   Milliseconds vrfyStart = Utilities::GetProcessorTime();
@@ -311,7 +315,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   if (vrfySched_) {
     bool isValidSchdul = bestSched->Verify(machMdl_, dataDepGraph_);
 
-    if (isValidSchdul == false) {
+    if (!isValidSchdul) {
       stats::invalidSchedules++;
     }
   }
@@ -329,7 +333,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   FinishOptml_();
 
   bool tookBest = ChkSchedule_(bestSched, lstSched);
-  if (tookBest == false) {
+  if (!tookBest) {
     bestCost_ = hurstcCost_;
     bestSchedLngth_ = hurstcSchedLngth_;
   }
@@ -337,9 +341,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   delete lstSchdulr;
   if (bestSched != lstSched)
     delete lstSched;
-  if (enumBestSched_ != NULL && bestSched != enumBestSched_)
+  if (enumBestSched_ != nullptr && bestSched != enumBestSched_)
     delete enumBestSched_;
-  if (enumCrntSched_ != NULL)
+  if (enumCrntSched_ != nullptr)
     delete enumCrntSched_;
 
   bestCost = bestCost_;
@@ -351,8 +355,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     bool optimal = isLstOptml || (rslt == RES_SUCCESS);
     if ((blocksToKeep == BLOCKS_TO_KEEP::ZERO_COST && bestCost != 0) ||
         (blocksToKeep == BLOCKS_TO_KEEP::OPTIMAL && !optimal) ||
-        (blocksToKeep == BLOCKS_TO_KEEP::IMPROVED &&
-         !(bestCost < hurstcCost)) ||
+        (blocksToKeep == BLOCKS_TO_KEEP::IMPROVED && bestCost >= hurstcCost) ||
         (blocksToKeep == BLOCKS_TO_KEEP::IMPROVED_OR_OPTIMAL &&
          !(optimal || bestCost < hurstcCost))) {
       delete bestSched;
@@ -483,8 +486,8 @@ FUNC_RESULT SchedRegion::Optimize_(Milliseconds startTime,
 }
 
 void SchedRegion::CmputLwrBounds_(bool useFileBounds) {
-  RelaxedScheduler *rlxdSchdulr = NULL;
-  RelaxedScheduler *rvrsRlxdSchdulr = NULL;
+  RelaxedScheduler *rlxdSchdulr = nullptr;
+  RelaxedScheduler *rvrsRlxdSchdulr = nullptr;
   InstCount rlxdUprBound = dataDepGraph_->GetAbslutSchedUprBound();
 
   switch (lbAlg_) {
@@ -502,7 +505,7 @@ void SchedRegion::CmputLwrBounds_(bool useFileBounds) {
     break;
   }
 
-  if (rlxdSchdulr == NULL || rvrsRlxdSchdulr == NULL) {
+  if (rlxdSchdulr == nullptr || rvrsRlxdSchdulr == nullptr) {
     Logger::Fatal("Out of memory.");
   }
 
@@ -605,8 +608,7 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
       SchedulerOptions::getInstance().GetString(
           "SIMULATE_REGISTER_ALLOCATION") == "TAKE_SCHED_WITH_LEAST_SPILLS") {
     // Simulate register allocation using the heuristic schedule.
-    u_regAllocList = std::unique_ptr<LocalRegAlloc>(
-        new LocalRegAlloc(lstSched, dataDepGraph_));
+    u_regAllocList = std::make_unique<LocalRegAlloc>(lstSched, dataDepGraph_);
 
     u_regAllocList->SetupForRegAlloc();
     u_regAllocList->AllocRegs();
@@ -624,8 +626,7 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
       SchedulerOptions::getInstance().GetString(
           "SIMULATE_REGISTER_ALLOCATION") == "TAKE_SCHED_WITH_LEAST_SPILLS") {
     // Simulate register allocation using the best schedule.
-    u_regAllocBest = std::unique_ptr<LocalRegAlloc>(
-        new LocalRegAlloc(bestSched, dataDepGraph_));
+    u_regAllocBest = std::make_unique<LocalRegAlloc>(bestSched, dataDepGraph_);
 
     u_regAllocBest->SetupForRegAlloc();
     u_regAllocBest->AllocRegs();


### PR DESCRIPTION
Add fixme annotations for clang-tidy violations which need attention

Same changes as #13, but rebased on top of 65ea3b2fcd52853198f4016fc206a58913640439.
