### PR TITLE
Fix bug in adjusted use calculation.

### DIFF
--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -698,12 +698,13 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
 void SchedInstruction::ComputeAdjustedUseCnt_() {
   Register **uses;
   int useCnt = GetUses(uses);
+  int tempAdjustedUseCnt = useCnt;
 
   for (int i = 0; i < useCnt; i++) {
     if (uses[i]->IsLiveOut())
-      useCnt--;
+      tempAdjustedUseCnt--;
   }
-  adjustedUseCnt_ = useCnt;
+  adjustedUseCnt_ = tempAdjustedUseCnt;
 }
 
 InstCount SchedInstruction::GetFileSchedOrder() const {

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -698,7 +698,7 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
 void SchedInstruction::ComputeAdjustedUseCnt_() {
   Register **uses;
   int useCnt = GetUses(uses);
-  adjustedUseCnt_ = GetUses(uses);
+  adjustedUseCnt_ = useCnt;
 
   for (int i = 0; i < useCnt; i++) {
     if (uses[i]->IsLiveOut())

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -698,13 +698,12 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
 void SchedInstruction::ComputeAdjustedUseCnt_() {
   Register **uses;
   int useCnt = GetUses(uses);
-  int tempAdjustedUseCnt = useCnt;
+  adjustedUseCnt_ = GetUses(uses);
 
   for (int i = 0; i < useCnt; i++) {
     if (uses[i]->IsLiveOut())
-      tempAdjustedUseCnt--;
+      adjustedUseCnt_--;
   }
-  adjustedUseCnt_ = tempAdjustedUseCnt;
 }
 
 InstCount SchedInstruction::GetFileSchedOrder() const {


### PR DESCRIPTION
For loop would terminate early if useCnt was deducted. This was causing incorrect adjusted use counts for some instructions.