### PR TITLE
Update conditions to determine if an instruction feeds a user.

### DIFF
--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -3260,16 +3260,16 @@ bool DataDepGraph::DoesFeedUser(SchedInstruction *inst) {
     SchedInstruction *succInst = static_cast<SchedInstruction *>(succ);
     
     int curInstAdjUseCnt = succInst->GetAdjustedUseCnt();
-    // Ignore successor instructions that does not close registers
+    // Ignore successor instructions that does not close live intervals
     if (curInstAdjUseCnt == 0)
       continue;
-    // Ignore instructions that define more registers than it closes
-    // because it will increase register pressure instead.
+    // Ignore instructions that open more live intervals than
+    // it closes because it will increase register pressure instead.
     else if (curInstAdjUseCnt < succInst->GetDefCnt())
       continue;
 
-    // If there is an adjusted use and it decreases register pressure
-    // or it does not increase register pressure, then return true.
+    // If there is a successor instruction that decreases live intervals
+    // or one that does not increase live intervals, then return true.
     return true;
 
   }

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -3258,19 +3258,20 @@ bool DataDepGraph::DoesFeedUser(SchedInstruction *inst) {
   for (GraphNode *succ = rcrsvSuccs->GetFrstElmnt(); succ != NULL;
        succ = rcrsvSuccs->GetNxtElmnt()) {
     SchedInstruction *succInst = static_cast<SchedInstruction *>(succ);
-    Register **uses;
-    int numUses = succInst->GetUses(uses);
+    
+    int curInstAdjUseCnt = succInst->GetAdjustedUseCnt();
+    // Ignore successor instructions that does not close registers
+    if (curInstAdjUseCnt == 0)
+      continue;
+    // Ignore instructions that define more registers than it closes
+    // because it will increase register pressure instead.
+    else if (curInstAdjUseCnt < succInst->GetDefCnt())
+      continue;
 
-    for (int i = 0; i < numUses; i++) {
-#ifdef IS_DEBUG_RP_ONLY
-      Logger::Info("inst %d has reg %d which has flag live/not-live: %d",
-                   succInst->GetNum(), uses[i]->GetNum(), uses[i]->IsLive());
-#endif
-      if (uses[i]->IsLive())
-        // If a register is live-in and live-out don't count it as a user.
-        if (!uses[i]->IsLiveOut())
-          return true;
-    }
+    // If there is an adjusted use and it decreases register pressure
+    // or it does not increase register pressure, then return true.
+    return true;
+
   }
 // Return false if there is no recursive successor of inst
 // that uses a live register.


### PR DESCRIPTION
Current instruction feeds a user if:
1.) It has a successor that has an adjusted use count greater than 0 (Use register is not live-out and will eventually be closed).
2.) The successor instruction does not define more registers than it uses.