### PR TITLE
Fix schedule specific region setting.

### DIFF
--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -137,7 +137,7 @@ static bool skipRegion(const StringRef RegionName, const Config &SchedIni) {
 
   const std::list<std::string> regionList =
       SchedIni.GetStringList("REGIONS_TO_SCHEDULE");
-  return std::find(std::begin(regionList), std::end(regionList), RegionName) !=
+  return std::find(std::begin(regionList), std::end(regionList), RegionName) ==
          std::end(regionList);
 }
 


### PR DESCRIPTION
Schedule specific region setting was skipping the regions listed instead of scheduling them only. This fixes the bug and only schedules the region specified if the setting is enabled.