### PR TITLE
[TWO-PASS] Output log for when each pass is finished.

### DIFF
--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -138,9 +138,13 @@ void ScheduleDAGOptSchedGCN::scheduleGCNMaxOcc() {
 }
 
 void ScheduleDAGOptSchedGCN::scheduleOptSchedMaxOcc() {
+  Logger::Info("Starting first pass");
   ScheduleDAGOptSched::scheduleOptSchedMinRP();
+  Logger::Info("End of first pass");
 }
 
 void ScheduleDAGOptSchedGCN::scheduleOptSchedBalanced() {
+  Logger::Info("Starting second pass");
   ScheduleDAGOptSched::scheduleOptSchedBalanced();
+  Logger::Info("End of second pass");
 }

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -138,13 +138,9 @@ void ScheduleDAGOptSchedGCN::scheduleGCNMaxOcc() {
 }
 
 void ScheduleDAGOptSchedGCN::scheduleOptSchedMaxOcc() {
-  Logger::Info("Starting first pass");
   ScheduleDAGOptSched::scheduleOptSchedMinRP();
-  Logger::Info("End of first pass");
 }
 
 void ScheduleDAGOptSchedGCN::scheduleOptSchedBalanced() {
-  Logger::Info("Starting second pass");
   ScheduleDAGOptSched::scheduleOptSchedBalanced();
-  Logger::Info("End of second pass");
 }

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -801,7 +801,7 @@ void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
   HeurSchedType = SCHED_LIST;
 
   schedule();
-  Logger::("End of first pass through\n");
+  Logger::Info("End of first pass through\n");
 }
 
 void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
@@ -825,7 +825,7 @@ void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
 
 
   schedule();
-  Logger::("End of second pass through");
+  Logger::Info("End of second pass through");
 }
 
 bool ScheduleDAGOptSched::isSimRegAllocEnabled() const {

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -794,7 +794,6 @@ void ScheduleDAGOptSched::runSchedPass(SchedPassStrategy S) {
 }
 
 void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
-  LLVM_DEBUG(dbgs() << "Starting first pass through\n");
   LatencyPrecision = LTP_UNITY;
   // Set times for the first pass
   RegionTimeout = FirstPassRegionTimeout;
@@ -802,10 +801,10 @@ void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
   HeurSchedType = SCHED_LIST;
 
   schedule();
+  Logger::("End of first pass through\n");
 }
 
 void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
-  LLVM_DEBUG(dbgs() << "Starting second pass through\n");
   SecondPass = true;
   LatencyPrecision = LTP_ROUGH;
   // Set times for the second pass
@@ -826,6 +825,7 @@ void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
 
 
   schedule();
+  Logger::("End of second pass through");
 }
 
 bool ScheduleDAGOptSched::isSimRegAllocEnabled() const {


### PR DESCRIPTION
By outputting a log for when each pass is finished, it will be easier to identify which pass the scheduling regions belongs to. This will make it much easier to write scripts to collect stats about how each pass is doing in terms of scheduling.