### PR TITLE
Fix comments for scheduler settings file.

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -1,8 +1,18 @@
 ﻿# Use optimizing scheduling
 # YES
-# NO
+# NO : No scheduling is done.
 # HOT_ONLY: Only use scheduler with hot functions.
 USE_OPT_SCHED YES
+
+# Print spill counts
+# Same options as use optimal scheduling.
+PRINT_SPILL_COUNTS YES
+
+# Use two pass scheduling approach. 
+# First pass minimizes RP and second pass tries to balances RP and ILP.
+# YES
+# NO
+USE_TWO_PASS NO
 
 # These 3 flags control which schedulers will be used.
 # Each one can be individually toggled. The heuristic
@@ -14,7 +24,7 @@ USE_OPT_SCHED YES
 # HEUR_ENABLED is the Heuristic scheduler.
 HEUR_ENABLED YES
 # ACO_ENABLED is the Ant Colony Optimization scheduler.
-ACO_ENABLED YES
+ACO_ENABLED NO
 # ENUM_ENABLED is the Branch and Bound scheduler.
 ENUM_ENABLED YES
 
@@ -28,18 +38,6 @@ ENUM_ENABLED YES
 ACO_BEFORE_ENUM YES
 # Run ACO after the enumerator
 ACO_AFTER_ENUM NO
-
-# Print spill counts
-# Same options as use optimal scheduling.
-PRINT_SPILL_COUNTS YES
-
-# Use two pass scheduling approach. 
-# This should only be used when selecting optsched
-# as the machine instruction scheduler with -misched=optsched.
-# First pass minimizes RP and second pass tries to balances RP and ILP.
-# YES
-# NO
-USE_TWO_PASS NO
 
 # A time limit for the whole region (basic block) in milliseconds. Defaults to no limit.
 # Interpretation depends on the TIMEOUT_PER setting.
@@ -118,19 +116,18 @@ LATENCY_PRECISION LLVM
 # The scheduler used to find an initial feasible schedule.
 # LIST: List scheduler
 # SEQ: Sequential list scheduler
-# ACO: Ant colony scheduler
 HEUR_SCHED_TYPE LIST
 
 #use 3-tournament
 ACO_TOURNAMENT YES
 
-#use fixd value fpr bais or not. If no, use ratio instaed
+#use fixd value for bias or not. If not, use ratio instaed
 ACO_USE_FIXED_BIAS YES
 
 #Fixed number of evaporation
 ACO_FIXED_BIAS 10
 
-# 0 to 1, ratio that will usee bais
+# 0 to 1, ratio that will use bias
 ACO_BIAS_RATIO 0.9
 
 ACO_LOCAL_DECAY 0.1


### PR DESCRIPTION
This patch does the following:
- Correct typos and clarify that setting `USE_OPT_SCHED` to `NO` does no scheduling.
- Moved the option to enable two-pass to the top since this is a fairly significant option for our current work.
- Set ACO to be disabled when using this example settings file.