### PR TITLE
Remove unnecessary null checks for new expressions

### DIFF
--- a/include/opt-sched/Scheduler/bit_vector.h
+++ b/include/opt-sched/Scheduler/bit_vector.h
@@ -86,8 +86,6 @@ inline void BitVector::Construct(int length) {
   if (vctr_)
     delete[] vctr_;
   vctr_ = new Unit[unitCnt_];
-  if (vctr_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (int i = 0; i < unitCnt_; i++) {
     vctr_[i] = 0;

--- a/include/opt-sched/Scheduler/enumerator.h
+++ b/include/opt-sched/Scheduler/enumerator.h
@@ -965,8 +965,6 @@ inline void Enumerator::CreateNewRdyLst_() {
   ReadyList *oldLst = rdyLst_;
 
   rdyLst_ = new ReadyList(dataDepGraph_, prirts_);
-  if (rdyLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   if (oldLst != NULL) {
     rdyLst_->CopyList(oldLst);

--- a/include/opt-sched/Scheduler/hash_table.h
+++ b/include/opt-sched/Scheduler/hash_table.h
@@ -340,9 +340,6 @@ inline void StrHashTblEntry<T>::Construct(const char *name, T *elmnt,
   HashTblEntry<T>::Construct_(elmnt, hashVal);
   name_ = new char[strlen(name) + 1];
 
-  if (name_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   strcpy(name_, name);
   indx_ = indx;
 }
@@ -389,12 +386,6 @@ HashTable<T>::HashTable(UDT_HASHVAL size, UDT_HASHTBL_CPCTY maxEntryCnt) {
   topEntry_ = new HashTblEntry<T> *[tblSize_];
   lastEntry_ = new HashTblEntry<T> *[tblSize_];
   entryCnts_ = new UDT_HASHTBL_CPCTY[tblSize_];
-
-  if (topEntry_ == NULL || lastEntry_ == NULL || entryCnts_ == NULL) {
-    isCnstrctd_ = false;
-    Logger::Error("Not enough memory for a hashtable of size %d.", tblSize_);
-    return;
-  }
 
   UDT_HASHVAL i;
 
@@ -629,8 +620,6 @@ BinHashTable<T>::InsertElement(const UDT_HASHKEY key, T *elmnt,
     newEntry->Construct(key, elmnt, hashVal);
   } else {
     newEntry = new BinHashTblEntry<T>(key, elmnt, hashVal);
-    if (newEntry == NULL)
-      Logger::Fatal("Out of memory.");
   }
 
   HashTable<T>::AddNewEntry_(newEntry, hashVal);
@@ -869,13 +858,6 @@ StrHashTable<T>::StrHashTable(UDT_HASHVAL size, bool useIndx,
     UDT_HASHTBL_CPCTY i;
     indxdTbl_ = new StrHashTblEntry<T> *[this->maxEntryCnt_];
 
-    if (indxdTbl_ == NULL) {
-      this->isCnstrctd_ = false;
-      Logger::Error("Could not allocate memory for a hash table of %d entries",
-                    this->maxEntryCnt_);
-      return;
-    }
-
     for (i = 0; i < this->maxEntryCnt_; i++) {
       indxdTbl_[i] = NULL;
     }
@@ -930,11 +912,6 @@ FUNC_RESULT StrHashTable<T>::InsertElement(const char *name, T *elmnt) {
 
   assert(!HashTable<T>::isExtrnlAlctr_);
   newEntry = new StrHashTblEntry<T>(name, elmnt, hashVal);
-
-  if (newEntry == NULL) {
-    Logger::Error("Recoverable memory allocation error.");
-    return RES_FAIL;
-  }
 
   AddNewEntry_(newEntry, hashVal);
 

--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -435,8 +435,6 @@ template <class T> Entry<T> *LinkedList<T>::AllocEntry_(T *element) {
 
   if (maxSize_ == INVALID_VALUE) {
     entry = new Entry<T>();
-    if (entry == NULL)
-      Logger::Fatal("Out of memory.");
   } else {
     assert(crntAllocIndx_ < maxSize_);
     entry = allocEntries_ + crntAllocIndx_;
@@ -450,8 +448,6 @@ template <class T> Entry<T> *LinkedList<T>::AllocEntry_(T *element) {
 template <class T> void LinkedList<T>::AllocEntries_() {
   assert(maxSize_ != INVALID_VALUE);
   allocEntries_ = new Entry<T>[maxSize_];
-  if (allocEntries_ == NULL)
-    Logger::Fatal("Out of memory.");
   crntAllocIndx_ = 0;
 }
 
@@ -641,8 +637,6 @@ KeyedEntry<T, K> *PriorityList<T, K>::AllocEntry_(T *element, K key) {
 
   if (LinkedList<T>::maxSize_ == INVALID_VALUE) {
     newEntry = new KeyedEntry<T, K>(element, key);
-    if (newEntry == NULL)
-      Logger::Fatal("Out of memory.");
   } else {
     assert(LinkedList<T>::crntAllocIndx_ < LinkedList<T>::maxSize_);
     newEntry = allocKeyEntries_ + LinkedList<T>::crntAllocIndx_;
@@ -656,8 +650,6 @@ KeyedEntry<T, K> *PriorityList<T, K>::AllocEntry_(T *element, K key) {
 
 template <class T, class K> void PriorityList<T, K>::AllocEntries_() {
   allocKeyEntries_ = new KeyedEntry<T, K>[LinkedList<T>::maxSize_];
-  if (allocKeyEntries_ == NULL)
-    Logger::Fatal("Out of memory.");
   LinkedList<T>::crntAllocIndx_ = 0;
 }
 

--- a/include/opt-sched/Scheduler/mem_mngr.h
+++ b/include/opt-sched/Scheduler/mem_mngr.h
@@ -118,8 +118,6 @@ template <class T> inline void MemAlloc<T>::GetNewBlock_() {
 
 template <class T> inline void MemAlloc<T>::AllocNewBlock_() {
   T *blk = new T[blockSize_];
-  if (blk == NULL)
-    Logger::Fatal("Out of memory.");
   allocatedBlocks_.InsrtElmnt(blk);
   currentIndex_ = 0;
   currentBlock_ = blk;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -780,8 +780,6 @@ Enumerator *BBWithSpill::AllocEnumrtr_(Milliseconds timeout) {
   enumrtr_ = new LengthCostEnumerator(
       dataDepGraph_, machMdl_, schedUprBound_, sigHashSize_, enumPrirts_,
       prune_, SchedForRPOnly_, enblStallEnum, timeout, spillCostFunc_, 0, NULL);
-  if (enumrtr_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   return enumrtr_;
 }

--- a/lib/Scheduler/buffers.cpp
+++ b/lib/Scheduler/buffers.cpp
@@ -75,8 +75,6 @@ FUNC_RESULT InputBuffer::Load(char const *const _fullPath, long maxByts) {
 
   // Allocate an extra byte for possible null termination.
   buf = new char[totSize + 1];
-  if (buf == NULL)
-    Logger::Fatal("Out of memory.");
   if ((loadedByts = read(fileHndl, buf, totSize)) == 0) {
     Logger::Fatal("Empty input file: %s.", fullPath);
   }

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -39,8 +39,6 @@ DataDepStruct::DataDepStruct(MachineModel *machMdl) {
   machMdl_ = machMdl;
   issuTypeCnt_ = (int16_t)machMdl->GetIssueTypeCnt();
   instCntPerIssuType_ = new InstCount[issuTypeCnt_];
-  if (instCntPerIssuType_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (int16_t i = 0; i < issuTypeCnt_; i++) {
     instCntPerIssuType_[i] = 0;
@@ -100,8 +98,6 @@ InstCount DataDepStruct::CmputRsrcLwrBound_() {
 
   int *slotsPerIssuType;
   slotsPerIssuType = new int[issuTypeCnt_];
-  if (slotsPerIssuType == NULL)
-    Logger::Fatal("Out of memory.");
 
   machMdl_->GetSlotsPerCycle(slotsPerIssuType);
 
@@ -185,8 +181,6 @@ DataDepGraph::DataDepGraph(MachineModel *machMdl, LATENCY_PRECISION ltncyPrcsn)
 
   instTypeCnt_ = (int16_t)machMdl->GetInstTypeCnt();
   instCntPerType_ = new InstCount[instTypeCnt_];
-  if (instCntPerType_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (i = 0; i < instTypeCnt_; i++) {
     instCntPerType_[i] = 0;
@@ -249,10 +243,6 @@ FUNC_RESULT DataDepGraph::SetupForSchdulng(bool cmputTrnstvClsr) {
 
   frwrdLwrBounds_ = new InstCount[instCnt_];
   bkwrdLwrBounds_ = new InstCount[instCnt_];
-
-  if (frwrdLwrBounds_ == NULL || bkwrdLwrBounds_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 
   CmputCrtclPaths_();
 
@@ -504,8 +494,6 @@ void DataDepGraph::AllocArrays_(InstCount instCnt) {
   instCnt_ = instCnt;
   nodeCnt_ = instCnt;
   insts_ = new SchedInstruction *[instCnt_];
-  if (insts_ == NULL)
-    Logger::Fatal("Out of memory.");
   nodes_ = (GraphNode **)insts_;
 
   for (i = 0; i < instCnt_; i++) {
@@ -843,8 +831,6 @@ SchedInstruction *DataDepGraph::CreateNode_(
   newInstPtr = new SchedInstruction(instNum, instName, instType, opCode,
                                     2 * instCnt_, nodeID, fileSchedOrder,
                                     fileSchedCycle, fileLB, fileUB, machMdl_);
-  if (newInstPtr == NULL)
-    Logger::Fatal("Out of memory.");
   if (instNum < 0 || instNum >= instCnt_)
     Logger::Fatal("Invalid instruction number");
   //  Logger::Info("Instruction order = %d, instCnt_ = %d", fileSchedOrder,
@@ -903,8 +889,6 @@ void DataDepGraph::CreateEdge(SchedInstruction *frmNode,
   }
 
   GraphEdge *newEdg = new GraphEdge(frmNode, toNode, ltncy, depType);
-  if (newEdg == NULL)
-    Logger::Fatal("Out of memory.");
 
   frmNode->AddScsr(newEdg);
   toNode->AddPrdcsr(newEdg);
@@ -945,8 +929,6 @@ void DataDepGraph::CreateEdge_(InstCount frmNodeNum, InstCount toNodeNum,
                  frmNodeNum, toNodeNum, depType, ltncy);
 #endif
     edge = new GraphEdge(frmNode, toNode, ltncy, depType);
-    if (edge == NULL)
-      Logger::Fatal("Out of memory.");
 
     frmNode->AddScsr(edge);
     toNode->AddPrdcsr(edge);
@@ -1334,8 +1316,6 @@ DataDepSubGraph::DataDepSubGraph(DataDepGraph *fullGraph, InstCount maxInstCnt,
   subType_ = SGT_DISC;
 
   insts_ = new SchedInstruction *[maxInstCnt_];
-  if (insts_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (i = 0; i < maxInstCnt; i++) {
     insts_[i] = NULL;
@@ -1363,19 +1343,12 @@ DataDepSubGraph::DataDepSubGraph(DataDepGraph *fullGraph, InstCount maxInstCnt,
 
   rootVctr_ = new BitVector(fullGraph_->GetInstCnt());
   leafVctr_ = new BitVector(fullGraph_->GetInstCnt());
-  if (rootVctr_ == NULL || leafVctr_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 
   numToIndx_ = new InstCount[fullGraph_->GetInstCnt()];
-  if (numToIndx_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   fxdLst_ = NULL;
 
   lostInsts_ = new Stack<LostInst>;
-  if (lostInsts_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (i = 0; i < fullGraph_->GetInstCnt(); i++) {
     numToIndx_[i] = INVALID_VALUE;
@@ -1437,8 +1410,6 @@ void DataDepSubGraph::SetupForDynmcLwrBounds(InstCount schedUprBound) {
 
   dynmcRlxdSchdulr_ = new RJ_RelaxedScheduler(
       this, machMdl_, subGraphUprBound, DIR_FRWRD, RST_SUBDYNMC, maxInstCnt_);
-  if (dynmcRlxdSchdulr_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   AllocDynmcData_();
 }
@@ -1447,25 +1418,13 @@ void DataDepSubGraph::AllocSttcData_() {
   frwrdCrtclPaths_ = new InstCount[maxInstCnt_];
   bkwrdCrtclPaths_ = new InstCount[maxInstCnt_];
 
-  if (frwrdCrtclPaths_ == NULL || bkwrdCrtclPaths_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
-
   frwrdLwrBounds_ = new InstCount[maxInstCnt_];
   bkwrdLwrBounds_ = new InstCount[maxInstCnt_];
-
-  if (frwrdLwrBounds_ == NULL || bkwrdLwrBounds_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 }
 
 void DataDepSubGraph::AllocDynmcData_() {
   dynmcFrwrdLwrBounds_ = new InstCount[maxInstCnt_];
   dynmcBkwrdLwrBounds_ = new InstCount[maxInstCnt_];
-
-  if (dynmcFrwrdLwrBounds_ == NULL || dynmcBkwrdLwrBounds_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 }
 
 // Called before lower bound computation after all instructions have been added
@@ -1563,16 +1522,12 @@ void DataDepSubGraph::CreateRootAndLeafInsts_() {
   rootInst_ =
       new SchedInstruction(INVALID_VALUE, "root", instType, " ", maxInstCnt_, 0,
                            INVALID_VALUE, INVALID_VALUE, 0, 0, machMdl_);
-  if (rootInst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   rootInst_->SetIssueType(issuType);
 
   leafInst_ =
       new SchedInstruction(INVALID_VALUE, "leaf", instType, " ", maxInstCnt_, 0,
                            INVALID_VALUE, INVALID_VALUE, 0, 0, machMdl_);
-  if (leafInst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   leafInst_->SetIssueType(issuType);
 
@@ -1724,8 +1679,6 @@ void DataDepSubGraph::InstLost(SchedInstruction *inst) {
   InstCount instIndx = numToIndx_[instNum];
   assert(instIndx != INVALID_VALUE);
   LostInst *lostInst = new LostInst;
-  if (lostInst == NULL)
-    Logger::Fatal("Out of memory.");
 
   lostInst->inst = inst;
   lostInst->indx = instIndx;
@@ -1875,8 +1828,6 @@ void DataDepSubGraph::CreateEdge_(SchedInstruction *frmInst,
 
   //  assert(frmInst==rootInst_ || toInst==leafInst_);
   GraphEdge *newEdg = new GraphEdge(frmNode, toNode, 1);
-  if (newEdg == NULL)
-    Logger::Fatal("Out of memory.");
 
   if (toInst != leafInst_) {
     frmNode->ApndScsr(newEdg);
@@ -2034,10 +1985,6 @@ void DataDepSubGraph::AllocRlxdSchdulr_(LB_ALG lbAlg,
         new LC_RelaxedScheduler(this, machMdl_, schedUprBound_, DIR_BKWRD);
     rlxdSchdulr = LCRlxdSchdulr_;
     rvrsRlxdSchdulr = LCRvrsRlxdSchdulr_;
-  }
-
-  if (rlxdSchdulr == NULL || rvrsRlxdSchdulr == NULL) {
-    Logger::Fatal("Out of memory.");
   }
 }
 
@@ -2659,11 +2606,6 @@ InstSchedule::InstSchedule(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   spillCosts_ = new InstCount[totInstCnt_];
   peakRegPressures_ = new InstCount[machMdl->GetRegTypeCnt()];
 
-  if (instInSlot_ == NULL || slotForInst_ == NULL || spillCosts_ == NULL ||
-      peakRegPressures_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
-
   InstCount i;
 
   for (i = 0; i < totInstCnt_; i++) {
@@ -3256,7 +3198,7 @@ bool DataDepGraph::DoesFeedUser(SchedInstruction *inst) {
   for (GraphNode *succ = rcrsvSuccs->GetFrstElmnt(); succ != NULL;
        succ = rcrsvSuccs->GetNxtElmnt()) {
     SchedInstruction *succInst = static_cast<SchedInstruction *>(succ);
-    
+
     int curInstAdjUseCnt = succInst->GetAdjustedUseCnt();
     // Ignore successor instructions that does not close live intervals
     if (curInstAdjUseCnt == 0)

--- a/lib/Scheduler/enumerator.cpp
+++ b/lib/Scheduler/enumerator.cpp
@@ -91,16 +91,8 @@ void EnumTreeNode::Construct(EnumTreeNode *prevNode, SchedInstruction *inst,
 
   if (isCnstrctd_ == false) {
     exmndInsts_ = new LinkedList<ExaminedInst>(instCnt);
-    if (exmndInsts_ == NULL)
-      Logger::Fatal("Out of memory.");
-
     chldrn_ = new LinkedList<HistEnumTreeNode>(instCnt);
-    if (chldrn_ == NULL)
-      Logger::Fatal("Out of memory.");
-
     frwrdLwrBounds_ = new InstCount[instCnt];
-    if (frwrdLwrBounds_ == NULL)
-      Logger::Fatal("Out of memory.");
   }
 
   if (enumrtr_->IsHistDom()) {
@@ -197,8 +189,6 @@ void EnumTreeNode::SetRsrvSlots(int16_t rsrvSlotCnt, ReserveSlot *rsrvSlots) {
   int issuRate = enumrtr_->machMdl_->GetIssueRate();
 
   rsrvSlots_ = new ReserveSlot[issuRate];
-  if (rsrvSlots_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (int i = 0; i < issuRate; i++) {
     rsrvSlots_[i].strtCycle = rsrvSlots[i].strtCycle;
@@ -261,8 +251,6 @@ void EnumTreeNode::NewBranchExmnd(SchedInstruction *inst, bool isLegal,
           ExaminedInst *exmndInst;
           exmndInst =
               new ExaminedInst(inst, wasRlxInfsbl, enumrtr_->dirctTightndLst_);
-          if (exmndInst == NULL)
-            Logger::Fatal("Out of memory.");
           exmndInsts_->InsrtElmnt(exmndInst);
         }
       }
@@ -473,9 +461,6 @@ Enumerator::Enumerator(DataDepGraph *dataDepGraph, MachineModel *machMdl,
                                          schedUprBound_ + SCHED_UB_EXTRA,
                                          DIR_FRWRD, RST_DYNMC, INVALID_VALUE);
 
-  if (rlxdSchdulr_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   for (int16_t i = 0; i < issuTypeCnt_; i++) {
     neededSlots_[i] = instCntPerIssuType_[i];
 #ifdef IS_DEBUG_ISSUE_TYPES
@@ -505,8 +490,6 @@ Enumerator::Enumerator(DataDepGraph *dataDepGraph, MachineModel *machMdl,
   if (IsHistDom()) {
     exmndSubProbs_ =
         new BinHashTable<HistEnumTreeNode>(sigSize, sigHashSize, true);
-    if (exmndSubProbs_ == NULL)
-      Logger::Fatal("Out of memory.");
   }
 
   histTableInitTime = Utilities::GetProcessorTime() - histTableInitTime;
@@ -518,24 +501,10 @@ Enumerator::Enumerator(DataDepGraph *dataDepGraph, MachineModel *machMdl,
   fxdLst_ = NULL;
 
   tightndLst_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (tightndLst_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   fxdLst_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (fxdLst_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   dirctTightndLst_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (dirctTightndLst_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   bkwrdTightndLst_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (bkwrdTightndLst_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   tmpLwrBounds_ = new InstCount[totInstCnt_];
-  if (tmpLwrBounds_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   SetInstSigs_();
   iterNum_ = 0;
@@ -573,31 +542,15 @@ void Enumerator::SetupAllocators_() {
 
   nodeAlctr_ = new EnumTreeNodeAlloc(maxNodeCnt);
 
-  if (nodeAlctr_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   if (IsHistDom()) {
     hashTblEntryAlctr_ =
         new MemAlloc<BinHashTblEntry<HistEnumTreeNode>>(memAllocBlkSize);
-    if (hashTblEntryAlctr_ == NULL)
-      Logger::Fatal("Out of memory.");
 
     bitVctr1_ = new BitVector(totInstCnt_);
     bitVctr2_ = new BitVector(totInstCnt_);
 
-    if (bitVctr1_ == NULL || bitVctr2_ == NULL) {
-      Logger::Fatal("Out of memory.");
-    }
-
     lastInsts_ = new SchedInstruction *[lastInstsEntryCnt];
-
-    if (lastInsts_ == NULL)
-      Logger::Fatal("Out of memory.");
-
     othrLastInsts_ = new SchedInstruction *[totInstCnt_];
-
-    if (othrLastInsts_ == NULL)
-      Logger::Fatal("Out of memory.");
   }
 }
 /****************************************************************************/
@@ -1820,9 +1773,6 @@ bool Enumerator::RlxdSchdul_(EnumTreeNode *newNode) {
   assert(newNode != NULL);
   LinkedList<SchedInstruction> *rsrcFxdLst = new LinkedList<SchedInstruction>;
 
-  if (rsrcFxdLst == NULL)
-    Logger::Fatal("Out of memory.");
-
   bool fsbl =
       rlxdSchdulr_->SchdulAndChkFsblty(crntCycleNum_, trgtSchedLngth_ - 1);
 
@@ -1910,9 +1860,6 @@ LengthEnumerator::LengthEnumerator(
                  preFxdInstCnt, preFxdInsts) {
   SetupAllocators_();
   tmpHstryNode_ = new HistEnumTreeNode;
-
-  if (tmpHstryNode_ == NULL)
-    Logger::Fatal("Out of memory.");
 }
 /*****************************************************************************/
 
@@ -1929,8 +1876,6 @@ void LengthEnumerator::SetupAllocators_() {
 
   if (IsHistDom()) {
     histNodeAlctr_ = new MemAlloc<HistEnumTreeNode>(memAllocBlkSize);
-    if (histNodeAlctr_ == NULL)
-      Logger::Fatal("Out of memory.");
   }
 }
 /****************************************************************************/
@@ -2009,8 +1954,6 @@ LengthCostEnumerator::LengthCostEnumerator(
   costLwrBound_ = 0;
   spillCostFunc_ = spillCostFunc;
   tmpHstryNode_ = new CostHistEnumTreeNode;
-  if (tmpHstryNode_ == NULL)
-    Logger::Fatal("Out of memory.");
 }
 /*****************************************************************************/
 
@@ -2027,8 +1970,6 @@ void LengthCostEnumerator::SetupAllocators_() {
 
   if (IsHistDom()) {
     histNodeAlctr_ = new MemAlloc<CostHistEnumTreeNode>(memAllocBlkSize);
-    if (histNodeAlctr_ == NULL)
-      Logger::Fatal("Out of memory.");
   }
 }
 /****************************************************************************/

--- a/lib/Scheduler/gen_sched.cpp
+++ b/lib/Scheduler/gen_sched.cpp
@@ -29,9 +29,6 @@ InstScheduler::InstScheduler(DataDepStruct *dataDepGraph, MachineModel *machMdl,
 
   slotsPerTypePerCycle_ = new int[issuTypeCnt_];
   instCntPerIssuType_ = new InstCount[issuTypeCnt_];
-  if (slotsPerTypePerCycle_ == NULL || instCntPerIssuType_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 
   issuTypeCnt_ = machMdl_->GetSlotsPerCycle(slotsPerTypePerCycle_);
 
@@ -47,8 +44,6 @@ InstScheduler::~InstScheduler() {
 
 void ConstrainedScheduler::AllocRsrvSlots_() {
   rsrvSlots_ = new ReserveSlot[issuRate_];
-  if (rsrvSlots_ == NULL)
-    Logger::Fatal("Out of memory.");
   ResetRsrvSlots_();
 }
 
@@ -73,8 +68,6 @@ ConstrainedScheduler::ConstrainedScheduler(DataDepGraph *dataDepGraph,
   // Allocate the array of first-ready lists - one list per cycle.
   assert(schedUprBound_ > 0);
   frstRdyLstPerCycle_ = new LinkedList<SchedInstruction> *[schedUprBound_];
-  if (frstRdyLstPerCycle_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (InstCount i = 0; i < schedUprBound_; i++) {
     frstRdyLstPerCycle_[i] = NULL;
@@ -90,8 +83,6 @@ ConstrainedScheduler::ConstrainedScheduler(DataDepGraph *dataDepGraph,
   consecEmptyCycles_ = 0;
 
   avlblSlotsInCrntCycle_ = new int16_t[issuTypeCnt_];
-  if (avlblSlotsInCrntCycle_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   rsrvSlots_ = NULL;
   rsrvSlotCnt_ = 0;
@@ -119,8 +110,6 @@ bool ConstrainedScheduler::Initialize_(InstCount trgtSchedLngth,
   // Allocate the first entry in the array.
   if (frstRdyLstPerCycle_[0] == NULL) {
     frstRdyLstPerCycle_[0] = new LinkedList<SchedInstruction>;
-    if (frstRdyLstPerCycle_[0] == NULL)
-      Logger::Fatal("Out of memory.");
   }
 
   frstRdyLstPerCycle_[0]->InsrtElmnt(rootInst_);
@@ -160,9 +149,6 @@ void ConstrainedScheduler::SchdulInst_(SchedInstruction *inst, InstCount) {
       // If the first-ready list of that cycle has not been created yet.
       if (frstRdyLstPerCycle_[scsrRdyCycle] == NULL) {
         frstRdyLstPerCycle_[scsrRdyCycle] = new LinkedList<SchedInstruction>;
-        if (frstRdyLstPerCycle_[scsrRdyCycle] == NULL) {
-          Logger::Fatal("Out of memory.");
-        }
       }
 
       // Add this succesor to the first-ready list of the future cycle

--- a/lib/Scheduler/graph.cpp
+++ b/lib/Scheduler/graph.cpp
@@ -16,9 +16,6 @@ GraphNode::GraphNode(UDT_GNODES num, UDT_GNODES maxNodeCnt) {
 
   scsrLst_ = new PriorityList<GraphEdge>(maxNodeCnt);
   prdcsrLst_ = new LinkedList<GraphEdge>(maxNodeCnt);
-  if (scsrLst_ == NULL || prdcsrLst_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
 
   rcrsvScsrLst_ = NULL;
   rcrsvPrdcsrLst_ = NULL;
@@ -109,10 +106,6 @@ void GraphNode::AllocRcrsvInfo(DIRECTION dir, UDT_GNODES nodeCnt) {
     assert(rcrsvScsrLst_ == NULL && isRcrsvScsr_ == NULL);
     rcrsvScsrLst_ = new LinkedList<GraphNode>;
     isRcrsvScsr_ = new BitVector(nodeCnt);
-
-    if (rcrsvScsrLst_ == NULL || isRcrsvScsr_ == NULL) {
-      Logger::Fatal("Out of memory.");
-    }
   } else {
     if (rcrsvPrdcsrLst_ != NULL) {
       delete rcrsvPrdcsrLst_;
@@ -125,10 +118,6 @@ void GraphNode::AllocRcrsvInfo(DIRECTION dir, UDT_GNODES nodeCnt) {
     assert(rcrsvPrdcsrLst_ == NULL && isRcrsvPrdcsr_ == NULL);
     rcrsvPrdcsrLst_ = new LinkedList<GraphNode>;
     isRcrsvPrdcsr_ = new BitVector(nodeCnt);
-
-    if (rcrsvPrdcsrLst_ == NULL || isRcrsvPrdcsr_ == NULL) {
-      Logger::Fatal("Out of memory.");
-    }
   }
 }
 
@@ -350,8 +339,6 @@ void DirAcycGraph::CreateEdge_(UDT_GNODES frmNodeNum, UDT_GNODES toNodeNum,
   assert(toNode != NULL);
 
   newEdg = new GraphEdge(frmNode, toNode, label);
-  if (newEdg == NULL)
-    Logger::Fatal("Out of memory.");
 
   frmNode->AddScsr(newEdg);
   toNode->AddPrdcsr(newEdg);
@@ -360,8 +347,6 @@ void DirAcycGraph::CreateEdge_(UDT_GNODES frmNodeNum, UDT_GNODES toNodeNum,
 FUNC_RESULT DirAcycGraph::DepthFirstSearch() {
   if (tplgclOrdr_ == NULL)
     tplgclOrdr_ = new GraphNode *[nodeCnt_];
-  if (tplgclOrdr_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (UDT_GNODES i = 0; i < nodeCnt_; i++) {
     nodes_[i]->SetColor(COL_WHITE);

--- a/lib/Scheduler/hist_table.cpp
+++ b/lib/Scheduler/hist_table.cpp
@@ -42,8 +42,6 @@ void HistEnumTreeNode::SetRsrvSlots_(EnumTreeNode *node) {
   int issuRate = node->enumrtr_->machMdl_->GetIssueRate();
 
   rsrvSlots_ = new ReserveSlot[issuRate];
-  if (rsrvSlots_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (int i = 0; i < issuRate; i++) {
     rsrvSlots_[i].strtCycle = node->rsrvSlots_[i].strtCycle;

--- a/lib/Scheduler/list_sched.cpp
+++ b/lib/Scheduler/list_sched.cpp
@@ -14,8 +14,6 @@ ListScheduler::ListScheduler(DataDepGraph *dataDepGraph, MachineModel *machMdl,
 
   prirts_ = prirts;
   rdyLst_ = new ReadyList(dataDepGraph_, prirts);
-  if (rdyLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 }
 
 ListScheduler::~ListScheduler() { delete rdyLst_; }

--- a/lib/Scheduler/ready_list.cpp
+++ b/lib/Scheduler/ready_list.cpp
@@ -78,12 +78,7 @@ ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts) {
 #endif
 
   prirtyLst_ = new PriorityList<SchedInstruction>;
-  if (prirtyLst_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   latestSubLst_ = new LinkedList<SchedInstruction>;
-  if (latestSubLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   int16_t keySize = 0;
   maxPriority_ = 0;

--- a/lib/Scheduler/relaxed_sched.cpp
+++ b/lib/Scheduler/relaxed_sched.cpp
@@ -38,26 +38,16 @@ RelaxedScheduler::RelaxedScheduler(DataDepStruct *dataDepGraph,
   }
 
   instLst_ = new PriorityList<SchedInstruction>(maxInstCnt_);
-  //  instLst_ = new PriorityList<SchedInstruction>;
-  if (instLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   for (InstCount i = 0; i < issuTypeCnt_; i++) {
     avlblSlots_[i] = new int16_t[schedUprBound_];
-    if (avlblSlots_[i] == NULL)
-      Logger::Fatal("Out of memory.");
-
     nxtAvlblCycles_[i] = new InstCount[schedUprBound_];
-    if (nxtAvlblCycles_[i] == NULL)
-      Logger::Fatal("Out of memory.");
   }
 
   isFxd_ = NULL;
 
   if (useFxng_) {
     isFxd_ = new bool[maxInstCnt_];
-    if (isFxd_ == NULL)
-      Logger::Fatal("Out of memory.");
 
     for (InstCount i = 0; i < maxInstCnt_; i++) {
       isFxd_[i] = false;
@@ -67,8 +57,6 @@ RelaxedScheduler::RelaxedScheduler(DataDepStruct *dataDepGraph,
   if (schedType_ == RST_DYNMC) {
     for (InstCount i = 0; i < issuTypeCnt_; i++) {
       prevAvlblSlots_[i] = new int16_t[schedUprBound_];
-      if (prevAvlblSlots_[i] == NULL)
-        Logger::Fatal("Out of memory.");
     }
   }
 
@@ -80,8 +68,6 @@ RelaxedScheduler::RelaxedScheduler(DataDepStruct *dataDepGraph,
 
 #ifdef IS_DEBUG
   wasLwrBoundCmputd_ = new bool[maxInstCnt_];
-  if (wasLwrBoundCmputd_ == NULL)
-    Logger::Fatal("Out of memory.");
 #endif
 }
 /*****************************************************************************/
@@ -608,10 +594,7 @@ LC_RelaxedScheduler::LC_RelaxedScheduler(DataDepStruct *dataDepGraph,
   // TEMP: Support for dynamic scheduling has not been implemented yet
   assert(schedType_ == RST_STTC);
 
-  //  subGraphInstLst_ = new PriorityList<SchedInstruction>(totInstCnt_);
   subGraphInstLst_ = new PriorityList<SchedInstruction>;
-  if (subGraphInstLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   schedDir_ = mainDir_;
 }
@@ -783,28 +766,14 @@ LPP_RelaxedScheduler::LPP_RelaxedScheduler(DataDepStruct *dataDepGraph,
   schedDir_ = DirAcycGraph::ReverseDirection(mainDir_);
 
   subGraphInstLst_ = new PriorityList<SchedInstruction>;
-  if (subGraphInstLst_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   crntFrwrdLwrBounds_ = new InstCount[totInstCnt_];
-  if (crntFrwrdLwrBounds_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   crntBkwrdLwrBounds_ = new InstCount[totInstCnt_];
-  if (crntBkwrdLwrBounds_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   tightndFrwrdLwrBounds_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (tightndFrwrdLwrBounds_ == NULL)
-    Logger::Fatal("Out of memory.");
-
   tightndBkwrdLwrBounds_ = new LinkedList<SchedInstruction>(totInstCnt_);
-  if (tightndBkwrdLwrBounds_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   lstEntries_ = new KeyedEntry<SchedInstruction> *[totInstCnt_];
-  if (lstEntries_ == NULL)
-    Logger::Fatal("Out of memory.");
 }
 /*****************************************************************************/
 

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -40,8 +40,6 @@ SchedInstruction::SchedInstruction(InstCount num, const string &name,
   unschduldScsrCnt_ = 0;
 
   crntRange_ = new SchedRange(this);
-  if (crntRange_ == NULL)
-    Logger::Fatal("Out of memory.");
 
   crntSchedCycle_ = SCHD_UNSCHDULD;
   crntRlxdCycle_ = SCHD_UNSCHDULD;
@@ -165,11 +163,6 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
   prevMinRdyCyclePerPrdcsr_ = new InstCount[prdcsrCnt_];
   sortedPrdcsrLst_ = new PriorityList<SchedInstruction>;
 
-  if (rdyCyclePerPrdcsr_ == NULL || ltncyPerPrdcsr_ == NULL ||
-      prevMinRdyCyclePerPrdcsr_ == NULL || sortedPrdcsrLst_ == NULL) {
-    Logger::Fatal("Out of memory.");
-  }
-
   InstCount predecessorIndex = 0;
   for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != NULL;
        edge = prdcsrLst_->GetNxtElmnt()) {
@@ -180,8 +173,6 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 
   if (isCP_FromScsr) {
     crtclPathFrmRcrsvScsr_ = new InstCount[instCnt];
-    if (crtclPathFrmRcrsvScsr_ == NULL)
-      Logger::Fatal("Out of memory.");
 
     for (InstCount i = 0; i < instCnt; i++) {
       crtclPathFrmRcrsvScsr_[i] = INVALID_VALUE;
@@ -192,8 +183,6 @@ void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
 
   if (isCP_FromPrdcsr) {
     crtclPathFrmRcrsvPrdcsr_ = new InstCount[instCnt];
-    if (crtclPathFrmRcrsvPrdcsr_ == NULL)
-      Logger::Fatal("Out of memory.");
 
     for (InstCount i = 0; i < instCnt; i++) {
       crtclPathFrmRcrsvPrdcsr_[i] = INVALID_VALUE;

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -65,8 +65,6 @@ void SchedRegion::UseFileBounds_() {
 InstSchedule *SchedRegion::AllocNewSched_() {
   InstSchedule *newSched =
       new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-  if (newSched == NULL)
-    Logger::Fatal("Out of memory.");
   return newSched;
 }
 
@@ -190,8 +188,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   if (HeuristicSchedulerEnabled || isSecondPass) {
     Milliseconds hurstcStart = Utilities::GetProcessorTime();
     lstSched = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-    if (lstSched == NULL)
-      Logger::Fatal("Out of memory.");
 
     lstSchdulr = AllocHeuristicScheduler_();
 
@@ -247,8 +243,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   if (AcoBeforeEnum && !isLstOptml) {
     AcoStart = Utilities::GetProcessorTime();
     AcoSchedule = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-    if (AcoSchedule == NULL)
-      Logger::Fatal("Out of memory.");
 
     rslt = runACO(AcoSchedule, lstSched);
     if (rslt != RES_SUCCESS) {
@@ -442,8 +436,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     Logger::Info("Final cost is not optimal, running ACO.");
     InstSchedule *AcoAfterEnumSchedule =
         new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
-    if (AcoAfterEnumSchedule == NULL)
-      Logger::Fatal("Out of memory");
 
     FUNC_RESULT acoRslt = runACO(AcoAfterEnumSchedule, bestSched);
     if (acoRslt != RES_SUCCESS) {
@@ -671,10 +663,6 @@ void SchedRegion::CmputLwrBounds_(bool useFileBounds) {
     rvrsRlxdSchdulr = new RJ_RelaxedScheduler(
         dataDepGraph_, machMdl_, rlxdUprBound, DIR_BKWRD, RST_STTC);
     break;
-  }
-
-  if (rlxdSchdulr == NULL || rvrsRlxdSchdulr == NULL) {
-    Logger::Fatal("Out of memory.");
   }
 
   InstCount frwrdLwrBound = 0;


### PR DESCRIPTION
Fixes #35

Ordinary new expressions never return `nullptr` on allocation failure.
Instead, they throw `std::bad_alloc`. Thus, all of these null checks
would never be triggered. As the only thing we did was log the error to
crash later, these null checks have been removed. The uncaught
`std::bad_alloc` exception serves the same purpose.