### PR TITLE
Disable RP-only graph transformations when LatencyPrecision is not unity

### DIFF
--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -175,13 +175,12 @@ void ScheduleDAGOptSched::addGraphTransformations(
   auto *GraphTransfomations = BDDG->GetGraphTrans();
 
   if (StaticNodeSup) {
-    if (LatencyPrecision != LTP_UNITY) {
+    if (LatencyPrecision == LTP_UNITY) {
+      GraphTransfomations->push_back(
+          createStaticNodeSupTrans(BDDG, MultiPassStaticNodeSup));
+    } else {
       Logger::Info("Skipping RP-only graph transforms for non-unity pass.");
-      return;
     }
-
-    GraphTransfomations->push_back(
-        createStaticNodeSupTrans(BDDG, MultiPassStaticNodeSup));
   }
 }
 


### PR DESCRIPTION
From discussion on #41, this adds code partially redundant with that PR to help ensure that RP-only graph transformations are only enabled for a LatencyPrecision of unity