### PR TITLE
Implemented Two pass ACO

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -118,6 +118,9 @@ LATENCY_PRECISION LLVM
 # SEQ: Sequential list scheduler
 HEUR_SCHED_TYPE LIST
 
+#aco two pass
+ACO_USE_TWO_PASS NO
+
 #use 3-tournament
 ACO_TOURNAMENT YES
 

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -21,6 +21,12 @@ struct Choice {
   double heuristic; // range 0 to 1
 };
 
+enum class ACOPass {
+  FIRST,
+  SECOND,
+  ALL_IN_ONE
+};
+
 class ACOScheduler : public ConstrainedScheduler {
 public:
   ACOScheduler(DataDepGraph *dataDepGraph, MachineModel *machineModel,
@@ -37,6 +43,9 @@ private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);
   pheremone_t &Pheremone(InstCount from, InstCount to);
   double Score(SchedInstruction *from, Choice choice);
+  FUNC_RESULT performSchedPass(InstSchedule *schedule_out);
+  bool shouldReplaceSchedule(ACOPass pass, InstSchedule* oldSched, InstSchedule* newSched);
+
 
   void PrintPheremone();
 
@@ -56,6 +65,8 @@ private:
   double decay_factor;
   int ants_per_iteration;
   bool print_aco_trace;
+  bool aco_use_two_pass;
+  ACOPass pass;
   std::vector<double> scores(std::vector<Choice> ready, SchedInstruction *last);
   InstSchedule* InitialSchedule;
   bool VrfySched_;

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -52,6 +52,8 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
   decay_factor = schedIni.GetFloat("ACO_DECAY_FACTOR");
   ants_per_iteration = schedIni.GetInt("ACO_ANT_PER_ITERATION");
   print_aco_trace = schedIni.GetBool("ACO_TRACE");
+  aco_use_two_pass = schedIni.GetBool("ACO_USE_TWO_PASS");
+
 
   /*
   std::cerr << "useOldAlg===="<<useOldAlg<<"\n\n";
@@ -115,7 +117,7 @@ SchedInstruction *ACOScheduler::SelectInstruction(std::vector<Choice> ready,
 
   if (RandDouble(0, 1) < choose_best_chance) {
     if (print_aco_trace)
-      std::cerr << "choose_best, use fixed bais: " << use_fixed_bias << "\n";
+      std::cerr << "choose_best, use fixed bias: " << use_fixed_bias << "\n";
     pheremone_t max = -1;
     Choice maxChoice;
     for (auto choice : ready) {
@@ -251,14 +253,59 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
                                        SchedRegion *region) {
   rgn_ = region;
 
+  if(!aco_use_two_pass)
+  {
+    pass = ACOPass::ALL_IN_ONE;
+    return performSchedPass(schedule_out);
+  }
+  else
+  {
+    //in the first pass we schedule for register pressure only
+    //in the second pass we schedule for lower schedule length
+    //but only accept schedules with an RP <= the first passes RP
+    //the first pass result is the initial schedule the second pass
+    pass = ACOPass::FIRST;
+    FUNC_RESULT pass1Res = performSchedPass(schedule_out);
+	if(pass1Res!=RES_SUCCESS) {
+      return pass1Res;
+    }
+    pass = ACOPass::SECOND;
+    setInitialSched(schedule_out);
+    return performSchedPass(schedule_out);
+
+  }
+}
+
+//compares to schedules taking into account which pass
+//we are on and returns whether the old schedule
+//is inferior to the new one and ought to be replaced
+bool ACOScheduler::shouldReplaceSchedule(ACOPass pass, InstSchedule* oldSched,
+                                         InstSchedule* newSched) {
+  //Logger::Info("old_sched_addr:%p, new_sched_addr:%p", oldSched, newSched);
+  return newSched!=NULL &&
+         (oldSched==NULL ||
+         (pass==ACOPass::FIRST &&
+         newSched->GetSpillCost() < oldSched->GetSpillCost()) ||
+         (pass==ACOPass::SECOND && newSched->GetCost() < oldSched->GetCost()
+         && newSched->GetSpillCost() <= oldSched->GetSpillCost()) ||
+         (pass==ACOPass::ALL_IN_ONE &&
+         newSched->GetCost() < oldSched->GetCost()));
+
+}
+
+FUNC_RESULT ACOScheduler::performSchedPass(InstSchedule *schedule_out) {
+
   // initialize pheremone
   // for this, we need the cost of the pure heuristic schedule
   int pheremone_size = (count_ + 1) * count_;
   for (int i = 0; i < pheremone_size; i++)
     pheremone_[i] = 1;
   initialValue_ = 1;
+  InstSchedule* heuSched = FindOneSchedule();
+  // the +1 is to prevent a divide by 0
   InstCount heuristicCost =
-      FindOneSchedule()->GetCost() + 1; // prevent divide by zero
+    (pass==ACOPass::FIRST ? heuSched->GetSpillCost():heuSched->GetCost()) + 1;
+  delete heuSched;
 
 #if USE_ACS
   initialValue_ = 2.0 / ((double)count_ * heuristicCost);
@@ -277,14 +324,14 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
   int noImprovementMax = schedIni.GetInt("ACO_STOP_ITERATIONS");
   int noImprovement = 0; // how many iterations with no improvement
   int iterations = 0;
+  bool passImproved = false;
   while (true) {
     InstSchedule *iterationBest = NULL;
     for (int i = 0; i < ants_per_iteration; i++) {
       InstSchedule *schedule = FindOneSchedule();
       if (print_aco_trace)
         PrintSchedule(schedule);
-      if (iterationBest == NULL ||
-          schedule->GetCost() < iterationBest->GetCost()) {
+      if (ACOScheduler::shouldReplaceSchedule(pass, iterationBest, schedule)) {
         delete iterationBest;
         iterationBest = schedule;
       } else {
@@ -297,12 +344,30 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
     /* PrintSchedule(iterationBest); */
     /* std::cout << iterationBest->GetCost() << std::endl; */
     // TODO DRY
-    if (bestSchedule == NULL ||
-        iterationBest->GetCost() < bestSchedule->GetCost()) {
+    if (ACOScheduler::shouldReplaceSchedule(pass, bestSchedule,
+                                            iterationBest)) {
       delete bestSchedule;
       bestSchedule = iterationBest;
-      Logger::Info("ACO found schedule with spill cost %d",
-                   bestSchedule->GetCost());
+      passImproved = true;
+      const char* passName;
+      switch(pass) {
+      case ACOPass::FIRST:
+        passName = "first";
+        break;
+      case ACOPass::SECOND:
+        passName = "second";
+        break;
+      case ACOPass::ALL_IN_ONE:
+        passName = "onepass";
+        break;
+      }
+      Logger::Info("ACO found schedule "
+                   "pass:%s, cost:%d, spill cost:%d, iteration:%d",
+                   passName,
+                   bestSchedule->GetCost(),
+                   bestSchedule->GetSpillCost(),
+                   iterations);
+
       noImprovement = 0;
     } else {
       delete iterationBest;
@@ -321,15 +386,28 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
   schedule_out->Copy(bestSchedule);
   delete bestSchedule;
 
-  Logger::Info("ACO finished after %d iterations", iterations);
+  switch(pass) {
+  case ACOPass::FIRST:
+    Logger::Info("ACO first pass finished after %d iterations", iterations);
+    break;
+  case ACOPass::SECOND:
+    Logger::Info("ACO second pass finished after %d iterations", iterations);
+    Logger::Info("ACO 2nd pass caused improvement: %s", (passImproved?"yes":"no"));
+    break;
+  case ACOPass::ALL_IN_ONE:
+    Logger::Info("ACO finished after %d iterations", iterations);
+    break;
+  }
   return RES_SUCCESS;
 }
 
 void ACOScheduler::UpdatePheremone(InstSchedule *schedule) {
   // I wish InstSchedule allowed you to just iterate over it, but it's got this
   // cycle and slot thing which needs to be accounted for
-  InstCount instNum, cycleNum, slotNum;
+  InstCount instNum, cycleNum, slotNum, schedCost;
   instNum = schedule->GetFrstInst(cycleNum, slotNum);
+  schedCost =
+    (pass==ACOPass::FIRST ? schedule->GetSpillCost() : schedule->GetCost())+1;
 
   SchedInstruction *lastInst = NULL;
   while (instNum != INVALID_VALUE) {
@@ -340,9 +418,9 @@ void ACOScheduler::UpdatePheremone(InstSchedule *schedule) {
     // ACS update rule includes decay
     // only the arcs on the current solution are decayed
     *pheremone = (1 - decay_factor) * *pheremone +
-                 decay_factor / (schedule->GetCost() + 1);
+                 decay_factor / schedCost;
 #else
-    *pheremone = *pheremone + 1 / (schedule->GetCost() + 1);
+    *pheremone = *pheremone + 1 / schedCost;
 #endif
     lastInst = inst;
 


### PR DESCRIPTION
Code for the ACO two pass scheduler. Prints extra information about ACO improvements to stdout.
Also fixes a small memory leak in the ACO scheduler. To to best of my knowledge this is llvm format compliant.