### PR TITLE
Replace raw pointers with unique_ptr and vector

### DIFF
--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -9,6 +9,8 @@ Last Update:  Jan. 2020
 #ifndef OPTSCHED_ACO_H
 #define OPTSCHED_ACO_H
 
+#include <vector>
+
 #include "opt-sched/Scheduler/gen_sched.h"
 
 namespace llvm {
@@ -29,10 +31,10 @@ public:
   virtual ~ACOScheduler();
   FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region);
   inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
-  // Set the initial schedule for ACO 
+  // Set the initial schedule for ACO
   // Default is NULL if none are set.
   void setInitialSched(InstSchedule *Sched);
-  
+
 private:
   pheremone_t &Pheremone(SchedInstruction *from, SchedInstruction *to);
   pheremone_t &Pheremone(InstCount from, InstCount to);
@@ -44,7 +46,7 @@ private:
                                       SchedInstruction *lastInst);
   void UpdatePheremone(InstSchedule *schedule);
   InstSchedule *FindOneSchedule();
-  pheremone_t *pheremone_;
+  std::vector<pheremone_t> pheremone_;
   pheremone_t initialValue_;
   bool use_fixed_bias;
   int count_;

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -14,6 +14,7 @@ Last Update:  Apr. 2011
 #include "opt-sched/Scheduler/sched_region.h"
 #include "llvm/ADT/SmallVector.h"
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -47,11 +48,11 @@ private:
 
   // A bit vector indexed by register number indicating whether that
   // register is live
-  WeightedBitVector *liveRegs_;
+  std::unique_ptr<WeightedBitVector[]> liveRegs_;
 
   // A bit vector indexed by physical register number indicating whether
   // that physical register is live
-  WeightedBitVector *livePhysRegs_;
+  std::unique_ptr<WeightedBitVector[]> livePhysRegs_;
 
   // Sum of lengths of live ranges. This vector is indexed by register type,
   // and each type will have its sum of live interval lengths computed.
@@ -70,10 +71,10 @@ private:
   int schduldExitInstCnt_;
   int schduldInstCnt_;
 
-  InstCount *spillCosts_;
+  std::vector<InstCount> spillCosts_;
   // Current register pressure for each register type.
   SmallVector<unsigned, 8> regPressures_;
-  InstCount *peakRegPressures_;
+  std::vector<InstCount> peakRegPressures_;
   InstCount crntStepNum_;
   InstCount peakSpillCost_;
   InstCount totSpillCost_;

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -63,13 +63,12 @@ ACOScheduler::ACOScheduler(DataDepGraph *dataDepGraph,
   std::cerr << "ants_per_iteration===="<<ants_per_iteration<<"\n\n";
   */
   int pheremone_size = (count_ + 1) * count_;
-  pheremone_ = new pheremone_t[pheremone_size];
+  pheremone_.resize(pheremone_size);
   InitialSchedule = nullptr;
 }
 
 ACOScheduler::~ACOScheduler() {
   delete rdyLst_;
-  delete[] pheremone_;
 }
 
 // Pheremone table lookup
@@ -253,7 +252,7 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
 
   // initialize pheremone
   // for this, we need the cost of the pure heuristic schedule
-  int pheremone_size = (count_ + 1) * count_;
+  int pheremone_size = pheremone_.size();
   for (int i = 0; i < pheremone_size; i++)
     pheremone_[i] = 1;
   initialValue_ = 1;


### PR DESCRIPTION
A very-much-WIP branch for replacing raw pointer arrays with either `unique_ptr<T[]>` or `vector<T>`.

I can say that this currently compiles, but I haven't run anything with it. See #47 . There's still a lot of work to do here and I'm not prioritizing this, but I figured it would be good to PR this to allow collaboration / prevent duplicate work. Feel free to push more related changes to this branch.

----

I'm preferring using `vector<T>` when possible, but if we are unsure if it is possible, `unique_ptr<T[]>` allows us to more closely replace the raw pointer.