### PR TITLE
Compare absolute costs

### DIFF
--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -181,6 +181,10 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   else
     CmputLwrBounds_(false);
 
+  // Log the lower bound on the cost, allowing tools reading the log to compare
+  // absolute rather than relative costs.
+  Logger::Info("Lower bound of cost before scheduling: %d", costLwrBound_);
+
   // Step #1: Find the heuristic schedule if enabled.
   // Note: Heuristic scheduler is required for the two-pass scheduler
   // to use the sequential list scheduler which inserts stalls into

--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -200,6 +200,7 @@ BLOCK_NAME_AND_SIZE_REGEX = re.compile(r'Processing DAG (.*) with (\d+) insts')
 BLOCK_NOT_ENUMERATED_REGEX = re.compile(r'The list schedule .* is optimal')
 BLOCK_ZERO_TIME_LIMIT = re.compile(r'Bypassing optimal scheduling due to zero time limit')
 BLOCK_ENUMERATED_OPTIMAL_REGEX = re.compile(r'DAG solved optimally')
+BLOCK_COST_LOWER_BOUND_REGEX = re.compile(r'Lower bound of cost before scheduling: (\d+)')
 BLOCK_COST_REGEX = re.compile(r'list schedule is of length \d+ and spill cost \d+. Tot cost = (\d+)')
 BLOCK_IMPROVEMENT_REGEX = re.compile(r'cost imp=(\d+)')
 BLOCK_START_TIME_REGEX = re.compile(r'-{20} \(Time = (\d+) ms\)')
@@ -626,7 +627,8 @@ def calculateBlockStats(output, trackOptSchedSpills):
                 else:
                     optSchedSpills = 0
 
-                listCost = int(BLOCK_COST_REGEX.findall(block)[0])
+                costLwrBound = int(BLOCK_COST_LOWER_BOUND_REGEX.search(block).group(1))
+                listCost = costLwrBound + int(BLOCK_COST_REGEX.findall(block)[0])
                 # The block is not enumerated if the list schedule is optimal or there is a zero
                 # time limit for enumeration.
                 isEnumerated = (BLOCK_NOT_ENUMERATED_REGEX.findall(block) == []) and (
@@ -919,5 +921,3 @@ if __name__ == '__main__':
                       help='Should the simulated number of spills per-block be tracked (%default).')
 
     main(parser.parse_args()[0])
-
-

--- a/util/SLIL/runspec-wrapper-SLIL.py
+++ b/util/SLIL/runspec-wrapper-SLIL.py
@@ -56,13 +56,14 @@ BLOCK_NAME_AND_SIZE_REGEX = re.compile(r'Processing DAG (.*) with (\d+) insts')
 #BLOCK_NOT_ENUMERATED_REGEX = re.compile(r'The list schedule .* is optimal')
 BLOCK_NOT_ENUMERATED_REGEX = re.compile(r'(Bypassing optimal scheduling due to zero time limit|The list schedule .* is optimal)')
 BLOCK_ENUMERATED_OPTIMAL_REGEX = re.compile(r'DAG solved optimally')
+BLOCK_COST_LOWER_BOUND_REGEX = re.compile(r'Lower bound of cost before scheduling: (\d+)')
 BLOCK_COST_REGEX = re.compile(r'list schedule is of length \d+ and spill cost \d+. Tot cost = (\d+)')
 BLOCK_IMPROVEMENT_REGEX = re.compile(r'cost imp=(\d+)')
 BLOCK_START_TIME_REGEX = re.compile(r'-{20} \(Time = (\d+) ms\)')
 BLOCK_END_TIME_REGEX = re.compile(r'verified successfully \(Time = (\d+) ms\)')
 BLOCK_LIST_FAILED_REGEX = re.compile(r'List scheduling failed')
 BLOCK_PEAK_REG_PRESSURE_REGEX = re.compile(r'PeakRegPresAfter Dag (.*?) Index (\d+) Name (.*) Peak (\d+) Limit (\d+)')
-SLIL_HEURISTIC_REGEX = re.compile('SLIL after Heuristic Scheduler for dag (.*?) Type (\d+) (.*?) is (\d+)')
+SLIL_HEURISTIC_REGEX = re.compile(r'SLIL after Heuristic Scheduler for dag (.*?) Type (\d+) (.*?) is (\d+)')
 BLOCK_FAILED_REGEX = re.compile(r'OptSched run failed')
 
 def writeStats(stats, args, dagSizesPerBenchmark):
@@ -448,7 +449,7 @@ def calculateBlockStats(output):
         end_time = int(BLOCK_END_TIME_REGEX.findall(block)[0])
         timeTaken = end_time - start_time
 
-        listCost = int(BLOCK_COST_REGEX.findall(block)[0])
+        listCost = int(BLOCK_COST_REGEX.findall(block)[0]) + int(BLOCK_COST_LOWER_BOUND_REGEX.search(block).group(1))
         isEnumerated = BLOCK_NOT_ENUMERATED_REGEX.findall(block) == []
         if isEnumerated:
           isOptimal = bool(BLOCK_ENUMERATED_OPTIMAL_REGEX.findall(block))

--- a/util/misc/validation-test.py
+++ b/util/misc/validation-test.py
@@ -19,8 +19,12 @@ dags2 = {}
 def dags_info(logtext):
     dags = {}
 
-    blocks = [block for block in RE_REGION_DELIMITER.split(logtext) if
-              RE_COST_LOWER_BOUND.search(block)]
+    unfiltered = RE_REGION_DELIMITER.split(logtext)
+    blocks = [block for block in unfiltered if RE_COST_LOWER_BOUND.search(block)]
+
+    if len(blocks) != len(unfiltered):
+        print('WARNING: {filtered}/{total} blocks do not have a logged lower bound.'
+            .format(filtered=len(blocks), total=len(unfiltered)), out=sys.stderr)
 
     for block in blocks:
         lowerBound = int(RE_COST_LOWER_BOUND.search(block).group(1))

--- a/util/misc/validation-test.py
+++ b/util/misc/validation-test.py
@@ -11,7 +11,7 @@ import re
 RE_COST_LOWER_BOUND = re.compile(r'INFO: Lower bound of cost before scheduling: (\d+)')
 RE_DAG_COST = re.compile(r"INFO: Best schedule for DAG (?P<name>.*) has cost (?P<cost>\d+) and length (?P<length>\d+). The schedule is (?P<optimal>.*) \(Time")
 
-RE_REGION_DELIMITER = re.compile(r'INFO: \Q****\E*? Opt Scheduling \Q****\E*')
+RE_REGION_DELIMITER = re.compile(r'INFO: \*{4,}? Opt Scheduling \*{4,}?')
 
 dags1 = {}
 dags2 = {}
@@ -22,12 +22,12 @@ def dags_info(logtext):
     blocks = [block for block in RE_REGION_DELIMITER.split(logtext) if
               RE_COST_LOWER_BOUND.search(block)]
 
-    for block in block:
+    for block in blocks:
         lowerBound = int(RE_COST_LOWER_BOUND.search(block).group(1))
         blockInfo = RE_DAG_COST.search(block).groupdict()
         dagName = blockInfo['name']
         dags[dagName] = {
-            'lowerBound': lowerBound
+            'lowerBound': lowerBound,
             'cost': int(blockInfo['cost']) + lowerBound,
             'relativeCost': int(blockInfo['cost']),
             'length': int(blockInfo['length']),

--- a/util/plaidbench/get-benchmarks-stats.py
+++ b/util/plaidbench/get-benchmarks-stats.py
@@ -40,7 +40,7 @@ from openpyxl import Workbook
 from openpyxl.styles import Font
 import argparse
 
-RE_DAG_INFO = re.compile('Processing DAG (.*) with (\d+) insts and max latency (\d+)')
+RE_DAG_INFO = re.compile(r'Processing DAG (.*) with (\d+) insts and max latency (\d+)')
 RE_PASS_NUM = re.compile(r'End of (.*) pass through')
 
 # Contains all of the stats
@@ -241,4 +241,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args)
-

--- a/util/plaidbench/get-optsched-stats.py
+++ b/util/plaidbench/get-optsched-stats.py
@@ -41,10 +41,10 @@ from openpyxl.styles import Font
 from openpyxl.styles import Alignment
 import argparse
 
-REGEX_DAG_INFO = re.compile('Processing DAG (.*) with (\d+) insts and max latency (\d+)')
-REGEX_LIST_OPTIMAL = re.compile('list schedule (.?)* is optimal')
-REGEX_COST_IMPROV = re.compile('cost imp=(\d+).')
-REGEX_OPTIMAL = re.compile('The schedule is optimal')
+REGEX_DAG_INFO = re.compile(r'Processing DAG (.*) with (\d+) insts and max latency (\d+)')
+REGEX_LIST_OPTIMAL = re.compile(r'list schedule (.?)* is optimal')
+REGEX_COST_IMPROV = re.compile(r'cost imp=(\d+).')
+REGEX_OPTIMAL = re.compile(r'The schedule is optimal')
 REGEX_PASS_NUM = re.compile(r'End of (.*) pass through')
 
 # Contains all of the stats
@@ -355,4 +355,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args)
-

--- a/util/plaidbench/get-sched-length.py
+++ b/util/plaidbench/get-sched-length.py
@@ -44,8 +44,8 @@ from openpyxl import Workbook
 from openpyxl.styles import Font
 
 # For AMD 
-RE_DAG_NAME = re.compile('Processing DAG (.*) with')
-RE_SCHED_LENGTH = re.compile('The list schedule is of length (\d+) and')
+RE_DAG_NAME = re.compile(r'Processing DAG (.*) with')
+RE_SCHED_LENGTH = re.compile(r'The list schedule is of length (\d+) and')
 
 # For OptSched
 RE_PASS_NUM = re.compile(r'End of (.*) pass through')

--- a/util/plaidbench/plaidbench-validation-test.py
+++ b/util/plaidbench/plaidbench-validation-test.py
@@ -48,6 +48,7 @@ benchmarks = [
 ]
 
 # Parse for DAG stats
+RE_DAG_COST_LOWER_BOUND = re.compile(r'Lower bound of cost before scheduling: (\d+)')
 RE_DAG_COST = re.compile(r'INFO: Best schedule for DAG (.*) has cost (\d+) and length (\d+). The schedule is (.*) \(Time')
 # Parse for passthrough number
 RE_PASS_NUM = re.compile(r'End of (.*) pass through')
@@ -199,11 +200,12 @@ def main(args):
                     passNum = getPass.group(1)
                     
                     # Get DAG stats
+                    dagLwrBound = RE_DAG_COST_LOWER_BOUND.search(block)
                     dagStats = RE_DAG_COST.search(block)
                     dag = {}
                     dagName = dagStats.group(1)
                     dag['dagName'] = dagName
-                    dag['cost'] = int(dagStats.group(2))
+                    dag['cost'] = int(dagStats.group(2)) + int(dagLwrBound.group(1))
                     dag['length'] = dagStats.group(3)
                     dag['isOptimal'] = (dagStats.group(4) == 'optimal')
                     
@@ -252,4 +254,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     main(args)
-


### PR DESCRIPTION
Many of our scripts were comparing relative costs rather than absolute costs. This interferes with analyzing graph transformations, because the graph transformations are run before the lower bound calculation. This means that the absolute reference point varies depending on whether graph transformations have been run.

To fix this, I'm unconditionally logging the lower bound and changing the scripts to compare absolute costs rather than relative costs.

-----

Did I miss any scripts?