### PR TITLE
Privatize / reduce scope of member variables

### DIFF
--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -389,7 +389,6 @@ protected:
                                 int nodeID, InstCount fileSchedOrder,
                                 InstCount fileSchedCycle, InstCount fileLB,
                                 InstCount fileUB, int blkNum);
-  void AddNode_(SchedInstruction *instPtr, InstCount instNum);
   FUNC_RESULT FinishNode_(InstCount nodeNum, InstCount edgeCnt = -1);
   void CreateEdge_(InstCount frmInstNum, InstCount toInstNum, int ltncy,
                    DependenceType depType);

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -172,8 +172,6 @@ public:
   void SetColor(GNODE_COLOR color);
   // Returns the color of this node.
   GNODE_COLOR GetColor() const;
-  // Sets the number (label) of the node.
-  void SetNum(UDT_GNODES num);
   // Returns the number (label) of the node.
   UDT_GNODES GetNum() const;
 
@@ -212,7 +210,14 @@ public:
   // info log.
   void LogScsrLst();
 
-protected:
+  // Returns the number of predecessors in this instruction's transitive
+  // closure (i.e. total number of ancestors).
+  UDT_GEDGES GetRcrsvPrdcsrCnt() const;
+  // Returns the number of successors in this instruction's transitive
+  // closure (i.e. total number of descendants).
+  UDT_GEDGES GetRcrsvScsrCnt() const;
+
+private:
   // The node number. Should be unique within a single graph.
   UDT_GNODES num_;
   // A list of the immediate successors of this node.
@@ -242,10 +247,34 @@ protected:
   // The color of this node, to be used during traversal.
   GNODE_COLOR color_;
 
+protected:
   // TODO(max): Document what this is.
   bool FindScsr_(GraphNode *&crntScsr, UDT_GNODES trgtNum, UDT_GLABEL trgtLbl);
   // Actually implements the functionality of FindRcrsvNghbrs().
   void FindRcrsvNghbrs_(GraphNode *root, DIRECTION dir, DirAcycGraph *graph);
+
+  // Returns the node's predecessor or successor list, depending on
+  // the specified direction.
+  LinkedList<GraphEdge> *GetNghbrLst(DIRECTION dir);
+
+  // Returns a pointer to the edge for the first successor of the node. Sets the
+  // successor iterator.
+  GraphEdge *GetFrstScsrEdge();
+  // Returns a pointer to the edge for the next successor of the node. Must be
+  // called after GetFrstScsr() or GetFrstScsrEdge(), which starts the successor
+  // iterator.
+  GraphEdge *GetNxtScsrEdge();
+  GraphEdge *GetLastScsrEdge();
+  GraphEdge *GetPrevScsrEdge();
+  // Returns a pointer to the edge for the first predecessor of the node. Sets
+  // the predecessor iterator.
+  GraphEdge *GetFrstPrdcsrEdge();
+  // Returns a pointer to the edge for the next predecessor of the node. Must be
+  // called after GetFrstPrdcsr() or GetFrstPrdcsrEdge(), which starts the
+  // predecessor iterator.
+  GraphEdge *GetNxtPrdcsrEdge();
+  GraphEdge *GetLastPrdcsrEdge();
+  GraphEdge *GetPrevPrdcsrEdge();
 };
 
 // TODO(max): Make this class actually useful by providing a way to add nodes
@@ -394,8 +423,6 @@ inline GNODE_COLOR GraphNode::GetColor() const { return color_; }
 
 inline UDT_GNODES GraphNode::GetNum() const { return num_; }
 
-inline void GraphNode::SetNum(UDT_GNODES num) { num_ = num; }
-
 inline GraphNode *GraphNode::GetFrstScsr(UDT_GLABEL &label) {
   GraphEdge *edge = scsrLst_->GetFrstElmnt();
   if (edge == NULL)
@@ -474,6 +501,50 @@ inline bool GraphNode::IsRcrsvNghbr(DIRECTION dir, GraphNode *node) const {
   } else {
     return IsRcrsvPrdcsr(node);
   }
+}
+
+inline UDT_GEDGES GraphNode::GetRcrsvPrdcsrCnt() const {
+  return rcrsvPrdcsrLst_->GetElmntCnt();
+}
+
+inline UDT_GEDGES GraphNode::GetRcrsvScsrCnt() const {
+  return rcrsvScsrLst_->GetElmntCnt();
+}
+
+inline LinkedList<GraphEdge> *GraphNode::GetNghbrLst(DIRECTION dir) {
+  return dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_;
+}
+
+inline GraphEdge *GraphNode::GetFrstScsrEdge() {
+  return scsrLst_->GetFrstElmnt();
+}
+
+inline GraphEdge *GraphNode::GetNxtScsrEdge() {
+  return scsrLst_->GetNxtElmnt();
+}
+
+inline GraphEdge *GraphNode::GetLastScsrEdge() {
+  return scsrLst_->GetLastElmnt();
+}
+
+inline GraphEdge *GraphNode::GetPrevScsrEdge() {
+  return scsrLst_->GetPrevElmnt();
+}
+
+inline GraphEdge *GraphNode::GetFrstPrdcsrEdge() {
+  return prdcsrLst_->GetFrstElmnt();
+}
+
+inline GraphEdge *GraphNode::GetNxtPrdcsrEdge() {
+  return prdcsrLst_->GetNxtElmnt();
+}
+
+inline GraphEdge *GraphNode::GetLastPrdcsrEdge() {
+  return prdcsrLst_->GetLastElmnt();
+}
+
+inline GraphEdge *GraphNode::GetPrevPrdcsrEdge() {
+  return prdcsrLst_->GetPrevElmnt();
 }
 
 inline DIRECTION DirAcycGraph::ReverseDirection(DIRECTION dir) {

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -176,17 +176,6 @@ public:
   // Returns the instruction's forward or backward lower bound.
   InstCount GetLwrBound(DIRECTION dir) const;
 
-  // Returns the number of predecessors of this instruction.
-  InstCount GetPrdcsrCnt() const;
-  // Returns the number of successors of this instruction node.
-  InstCount GetScsrCnt() const;
-  // Returns the number of predecessors in this instructions transitive
-  // closure (i.e. total number of ancestors).
-  InstCount GetRcrsvPrdcsrCnt() const;
-  // Returns the number of successors in this instructions transitive
-  // closure (i.e. total number of descendants).
-  InstCount GetRcrsvScsrCnt() const;
-
   /***************************************************************************
    * Iterators                                                               *
    ***************************************************************************/

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -3075,12 +3075,6 @@ SchedInstruction *DataDepGraph::GetLeafInst() {
   return (SchedInstruction *)leaf_;
 }
 
-void DataDepGraph::AddNode_(SchedInstruction *instPtr, InstCount instNum) {
-  assert(instNum < instCnt_);
-  insts_[instNum] = instPtr;
-  instPtr->SetNum(instNum);
-}
-
 void DataDepGraph::CmputCrtclPathsFrmRoot_() {
   InstCount i;
 

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -156,16 +156,16 @@ bool SchedInstruction::InitForSchdulng(InstCount schedLngth,
 
 void SchedInstruction::AllocMem_(InstCount instCnt, bool isCP_FromScsr,
                                  bool isCP_FromPrdcsr) {
-  scsrCnt_ = scsrLst_->GetElmntCnt();
-  prdcsrCnt_ = prdcsrLst_->GetElmntCnt();
+  scsrCnt_ = GetScsrCnt();
+  prdcsrCnt_ = GetPrdcsrCnt();
   rdyCyclePerPrdcsr_ = new InstCount[prdcsrCnt_];
   ltncyPerPrdcsr_ = new InstCount[prdcsrCnt_];
   prevMinRdyCyclePerPrdcsr_ = new InstCount[prdcsrCnt_];
   sortedPrdcsrLst_ = new PriorityList<SchedInstruction>;
 
   InstCount predecessorIndex = 0;
-  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != NULL;
-       edge = prdcsrLst_->GetNxtElmnt()) {
+  for (GraphEdge *edge = GetFrstPrdcsrEdge(); edge != NULL;
+       edge = GetNxtPrdcsrEdge()) {
     ltncyPerPrdcsr_[predecessorIndex++] = edge->label;
     sortedPrdcsrLst_->InsrtElmnt((SchedInstruction *)edge->GetOtherNode(this),
                                  edge->label, true);
@@ -222,7 +222,7 @@ InstCount SchedInstruction::CmputCrtclPath_(DIRECTION dir,
   // predecessor (successor) and then taking the maximum value among all these
   // paths.
   InstCount crtclPath = 0;
-  LinkedList<GraphEdge> *nghbrLst = (dir == DIR_FRWRD) ? prdcsrLst_ : scsrLst_;
+  LinkedList<GraphEdge> *nghbrLst = GetNghbrLst(dir);
 
   for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
        edg = nghbrLst->GetNxtElmnt()) {
@@ -341,30 +341,10 @@ int SchedInstruction::GetLtncySum() const { return GetScsrLblSum(); }
 
 int SchedInstruction::GetMaxLtncy() const { return GetMaxEdgeLabel(); }
 
-InstCount SchedInstruction::GetPrdcsrCnt() const {
-  return prdcsrLst_->GetElmntCnt();
-}
-
-InstCount SchedInstruction::GetScsrCnt() const {
-  return scsrLst_->GetElmntCnt();
-}
-
-InstCount SchedInstruction::GetRcrsvPrdcsrCnt() const {
-  assert(rcrsvPrdcsrLst_ != NULL);
-  assert(rcrsvPrdcsrLst_->GetElmntCnt() >= prdcsrCnt_);
-  return rcrsvPrdcsrLst_->GetElmntCnt();
-}
-
-InstCount SchedInstruction::GetRcrsvScsrCnt() const {
-  assert(rcrsvScsrLst_ != NULL);
-  assert(rcrsvScsrLst_->GetElmntCnt() >= scsrCnt_);
-  return rcrsvScsrLst_->GetElmntCnt();
-}
-
 SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
                                                   UDT_GLABEL *ltncy,
                                                   DependenceType *depType) {
-  GraphEdge *edge = prdcsrLst_->GetFrstElmnt();
+  GraphEdge *edge = GetFrstPrdcsrEdge();
   if (!edge)
     return NULL;
   if (scsrNum)
@@ -379,7 +359,7 @@ SchedInstruction *SchedInstruction::GetFrstPrdcsr(InstCount *scsrNum,
 SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
                                                  UDT_GLABEL *ltncy,
                                                  DependenceType *depType) {
-  GraphEdge *edge = prdcsrLst_->GetNxtElmnt();
+  GraphEdge *edge = GetNxtPrdcsrEdge();
   if (!edge)
     return NULL;
   if (scsrNum)
@@ -394,7 +374,7 @@ SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
 SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
                                                 UDT_GLABEL *ltncy,
                                                 DependenceType *depType) {
-  GraphEdge *edge = scsrLst_->GetFrstElmnt();
+  GraphEdge *edge = GetFrstScsrEdge();
   if (!edge)
     return NULL;
   if (prdcsrNum)
@@ -409,7 +389,7 @@ SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
 SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
                                                UDT_GLABEL *ltncy,
                                                DependenceType *depType) {
-  GraphEdge *edge = scsrLst_->GetNxtElmnt();
+  GraphEdge *edge = GetNxtScsrEdge();
   if (!edge)
     return NULL;
   if (prdcsrNum)
@@ -422,7 +402,7 @@ SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
 }
 
 SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
-  GraphEdge *edge = scsrLst_->GetLastElmnt();
+  GraphEdge *edge = GetLastScsrEdge();
   if (!edge)
     return NULL;
   if (prdcsrNum)
@@ -431,7 +411,7 @@ SchedInstruction *SchedInstruction::GetLastScsr(InstCount *prdcsrNum) {
 }
 
 SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
-  GraphEdge *edge = scsrLst_->GetPrevElmnt();
+  GraphEdge *edge = GetPrevScsrEdge();
   if (!edge)
     return NULL;
   if (prdcsrNum)
@@ -441,7 +421,7 @@ SchedInstruction *SchedInstruction::GetPrevScsr(InstCount *prdcsrNum) {
 
 SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
                                                  UDT_GLABEL *ltncy) {
-  GraphEdge *edge = (dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_)->GetFrstElmnt();
+  GraphEdge *edge = dir == DIR_FRWRD ? GetFrstScsrEdge() : GetFrstPrdcsrEdge();
   if (edge == NULL)
     return NULL;
   if (ltncy)
@@ -451,7 +431,7 @@ SchedInstruction *SchedInstruction::GetFrstNghbr(DIRECTION dir,
 
 SchedInstruction *SchedInstruction::GetNxtNghbr(DIRECTION dir,
                                                 UDT_GLABEL *ltncy) {
-  GraphEdge *edge = (dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_)->GetNxtElmnt();
+  GraphEdge *edge = dir == DIR_FRWRD ? GetNxtScsrEdge() : GetNxtPrdcsrEdge();
   if (edge == NULL)
     return NULL;
   if (ltncy)
@@ -668,9 +648,8 @@ bool SchedInstruction::ProbeScsrsCrntLwrBounds(InstCount cycle) {
   if (cycle <= crntRange_->GetLwrBound(DIR_FRWRD))
     return false;
 
-  LinkedList<GraphEdge> *nghbrLst = scsrLst_;
-  for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
-       edg = nghbrLst->GetNxtElmnt()) {
+  for (GraphEdge *edg = GetFrstScsrEdge(); edg != NULL;
+       edg = GetNxtScsrEdge()) {
     UDT_GLABEL edgLbl = edg->label;
     SchedInstruction *nghbr = (SchedInstruction *)(edg->GetOtherNode(this));
     InstCount nghbrNewLwrBound = cycle + edgLbl;
@@ -706,8 +685,8 @@ InstCount SchedInstruction::GetFileSchedCycle() const {
 void SchedInstruction::SetScsrNums_() {
   InstCount scsrNum = 0;
 
-  for (GraphEdge *edge = scsrLst_->GetFrstElmnt(); edge != NULL;
-       edge = scsrLst_->GetNxtElmnt()) {
+  for (GraphEdge *edge = GetFrstScsrEdge(); edge != NULL;
+       edge = GetNxtScsrEdge()) {
     edge->succOrder = scsrNum++;
   }
 
@@ -717,8 +696,8 @@ void SchedInstruction::SetScsrNums_() {
 void SchedInstruction::SetPrdcsrNums_() {
   InstCount prdcsrNum = 0;
 
-  for (GraphEdge *edge = prdcsrLst_->GetFrstElmnt(); edge != NULL;
-       edge = prdcsrLst_->GetNxtElmnt()) {
+  for (GraphEdge *edge = GetFrstPrdcsrEdge(); edge != NULL;
+       edge = GetNxtPrdcsrEdge()) {
     edge->predOrder = prdcsrNum++;
   }
 
@@ -805,8 +784,11 @@ bool SchedRange::TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newBound,
                                        LinkedList<SchedInstruction> *tightndLst,
                                        LinkedList<SchedInstruction> *fxdLst,
                                        bool enforce) {
-  LinkedList<GraphEdge> *nghbrLst =
-      (dir == DIR_FRWRD) ? inst_->scsrLst_ : inst_->prdcsrLst_;
+  auto getNextNeighbor =
+      dir == DIR_FRWRD
+          ? +[](SchedRange &range) { return range.inst_->GetNxtScsrEdge(); }
+          : +[](SchedRange &range) { return range.inst_->GetNxtPrdcsrEdge(); };
+
   InstCount crntBound = (dir == DIR_FRWRD) ? frwrdLwrBound_ : bkwrdLwrBound_;
   bool fsbl = IsFsbl_();
 
@@ -819,8 +801,9 @@ bool SchedRange::TightnLwrBoundRcrsvly(DIRECTION dir, InstCount newBound,
     if (!fsbl && !enforce)
       return false;
 
-    for (GraphEdge *edg = nghbrLst->GetFrstElmnt(); edg != NULL;
-         edg = nghbrLst->GetNxtElmnt()) {
+    for (GraphEdge *edg = dir == DIR_FRWRD ? inst_->GetFrstScsrEdge()
+                                           : inst_->GetFrstPrdcsrEdge();
+         edg != NULL; edg = getNextNeighbor(*this)) {
       UDT_GLABEL edgLbl = edg->label;
       SchedInstruction *nghbr = (SchedInstruction *)(edg->GetOtherNode(inst_));
       InstCount nghbrNewBound = newBound + edgLbl;

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -23,7 +23,8 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
                          long rgnNum, int16_t sigHashSize, LB_ALG lbAlg,
                          SchedPriorities hurstcPrirts,
                          SchedPriorities enumPrirts, bool vrfySched,
-                         Pruning PruningStrategy, SchedulerType HeurSchedType) {
+                         Pruning PruningStrategy, SchedulerType HeurSchedType,
+                         SPILL_COST_FUNCTION spillCostFunc) {
   machMdl_ = machMdl;
   dataDepGraph_ = dataDepGraph;
   rgnNum_ = rgnNum;
@@ -34,23 +35,18 @@ SchedRegion::SchedRegion(MachineModel *machMdl, DataDepGraph *dataDepGraph,
   vrfySched_ = vrfySched;
   prune_ = PruningStrategy;
   HeurSchedType_ = HeurSchedType;
-  isSecondPass = false;
+  isSecondPass_ = false;
 
   totalSimSpills_ = INVALID_VALUE;
   bestCost_ = INVALID_VALUE;
   bestSchedLngth_ = INVALID_VALUE;
   hurstcCost_ = INVALID_VALUE;
-  hurstcSchedLngth_ = INVALID_VALUE;
-  AcoScheduleCost_ = INVALID_VALUE;
-  AcoScheduleLength_ = INVALID_VALUE;
   enumCrntSched_ = NULL;
   enumBestSched_ = NULL;
   schedLwrBound_ = 0;
   schedUprBound_ = INVALID_VALUE;
 
-  instCnt_ = dataDepGraph_->GetInstCnt();
-
-  needTrnstvClsr_ = false;
+  spillCostFunc_ = spillCostFunc;
 }
 
 void SchedRegion::UseFileBounds_() {
@@ -103,6 +99,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   Milliseconds vrfyTime = 0;
   Milliseconds AcoTime = 0;
   Milliseconds AcoStart = 0;
+  InstCount heuristicScheduleLength = INVALID_VALUE;
+  InstCount AcoScheduleLength_ = INVALID_VALUE;
+  InstCount AcoScheduleCost_ = INVALID_VALUE;
 
   enumCrntSched_ = NULL;
   enumBestSched_ = NULL;
@@ -110,6 +109,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
   bool AcoBeforeEnum = false;
   bool AcoAfterEnum = false;
+
+  // Do we need to compute the graph's transitive closure?
+  bool needTransitiveClosure = false;
 
   // Algorithm run order:
   // 1) Heuristic Scheduler
@@ -147,9 +149,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   const auto *GraphTransformations = dataDepGraph_->GetGraphTrans();
   if (BbSchedulerEnabled || GraphTransformations->size() > 0 ||
       spillCostFunc_ == SCF_SLIL)
-    needTrnstvClsr_ = true;
+    needTransitiveClosure = true;
 
-  rslt = dataDepGraph_->SetupForSchdulng(needTrnstvClsr_);
+  rslt = dataDepGraph_->SetupForSchdulng(needTransitiveClosure);
   if (rslt != RES_SUCCESS) {
     Logger::Info("Invalid input DAG");
     return rslt;
@@ -163,7 +165,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
       return rslt;
 
     // Update graph after each transformation
-    rslt = dataDepGraph_->UpdateSetupForSchdulng(needTrnstvClsr_);
+    rslt = dataDepGraph_->UpdateSetupForSchdulng(needTransitiveClosure);
     if (rslt != RES_SUCCESS) {
       Logger::Info("Invalid DAG after graph transformations");
       return rslt;
@@ -189,7 +191,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   // Note: Heuristic scheduler is required for the two-pass scheduler
   // to use the sequential list scheduler which inserts stalls into
   // the schedule found in the first pass.
-  if (HeuristicSchedulerEnabled || isSecondPass) {
+  if (HeuristicSchedulerEnabled || IsSecondPass()) {
     Milliseconds hurstcStart = Utilities::GetProcessorTime();
     lstSched = new InstSchedule(machMdl_, dataDepGraph_, vrfySched_);
 
@@ -209,7 +211,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     if (hurstcTime > 0)
       Logger::Info("Heuristic_Time %d", hurstcTime);
 
-    hurstcSchedLngth_ = lstSched->GetCrntLngth();
+    heuristicScheduleLength = lstSched->GetCrntLngth();
     InstCount hurstcExecCost;
     // Compute cost for Heuristic list scheduler, this must be called before
     // calling GetCost() on the InstSchedule instance.
@@ -221,7 +223,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     if (hurstcCost_ == 0) {
       isLstOptml = true;
       bestSched = bestSched_ = lstSched;
-      bestSchedLngth_ = hurstcSchedLngth_;
+      bestSchedLngth_ = heuristicScheduleLength;
       bestCost_ = hurstcCost_;
     }
 
@@ -230,7 +232,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     //  #ifdef IS_DEBUG_SOLN_DETAILS_1
     Logger::Info(
         "The list schedule is of length %d and spill cost %d. Tot cost = %d",
-        hurstcSchedLngth_, lstSched->GetSpillCost(), hurstcCost_);
+        heuristicScheduleLength, lstSched->GetSpillCost(), hurstcCost_);
     //  #endif
 
 #ifdef IS_DEBUG_PRINT_SCHEDS
@@ -290,7 +292,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     // results, into B&B.
     if (!AcoBeforeEnum) {
       bestSched = bestSched_ = lstSched;
-      bestSchedLngth_ = hurstcSchedLngth_;
+      bestSchedLngth_ = heuristicScheduleLength;
       bestCost_ = hurstcCost_;
     }
     // B) Heuristic was never run. In that case, just use ACO and run with its
@@ -509,7 +511,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   bestCost = bestCost_;
   bestSchedLngth = bestSchedLngth_;
   hurstcCost = hurstcCost_;
-  hurstcSchedLngth = hurstcSchedLngth_;
+  hurstcSchedLngth = heuristicScheduleLength;
 
   // (Chris): Experimental. Discard the schedule based on sched.ini setting.
   if (spillCostFunc_ == SCF_SLIL) {
@@ -706,7 +708,7 @@ bool SchedRegion::CmputUprBounds_(InstSchedule *schedule, bool useFileBounds) {
     // If the heuristic schedule is optimal, we are done!
     schedUprBound_ = bestSchedLngth_;
     return true;
-  } else if (isSecondPass) {
+  } else if (IsSecondPass()) {
     // In the second pass, the upper bound is the length of the min-RP schedule
     // that was found in the first pass with stalls inserted.
     schedUprBound_ = schedule->GetCrntLngth();
@@ -805,7 +807,7 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
     }
 }
 
-void SchedRegion::InitSecondPass() { isSecondPass = true; }
+void SchedRegion::InitSecondPass() { isSecondPass_ = true; }
 
 FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
                                 InstSchedule *InitSched) {


### PR DESCRIPTION
See #47 

The goal here is to move member variables from `protected` to `private`, or even to remove them altogether in favor of local variables. Reducing the scope of the variable makes the code easier to follow, as it's clearer where the variable is changed.

This is a draft. There's much more work to do. However, I would like to know your thoughts on what's being done before the whole thing is finished.