### PR TITLE
Fix validation test warning

### DIFF
--- a/util/misc/validation-test.py
+++ b/util/misc/validation-test.py
@@ -24,7 +24,7 @@ dags2 = {}
 def dags_info(logtext):
     dags = {}
 
-    unfiltered = RE_REGION_DELIMITER.split(logtext)
+    unfiltered = RE_REGION_DELIMITER.split(logtext)[1:]
     blocks = [block for block in unfiltered if RE_COST_LOWER_BOUND.search(block)]
 
     if len(blocks) != len(unfiltered):


### PR DESCRIPTION
Fixes #58 

Clarify the warning message so that it states the number of blocks missing the logged lower bound out of the number of total blocks.

Fix `out=sys.stderr` -> `file=sys.stderr`.

Print out a small number of (trimmed) blocks missing the lower bound, to make it easier to debug missing lower bounds.

The first of the so-called "blocks" wasn't actually a block. `regex.split(text)`'s first result is everything up to the first match, meaning that the first element of the list is not a match. Dropping this first result fixes the spurious warning.