### PR TITLE
Fix script issue with detecting block enumeration.

### DIFF
--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -197,9 +197,8 @@ SPILLS_REGEX = re.compile(r'Function: (.*?)\nGREEDY RA: Number of spilled live r
 SPILLS_WEIGHTED_REGEX = re.compile(r'SC in Function (.*?) (-?\d+)')
 TIMES_REGEX = re.compile(r'(\d+) total seconds elapsed')
 BLOCK_NAME_AND_SIZE_REGEX = re.compile(r'Processing DAG (.*) with (\d+) insts')
-BLOCK_NOT_ENUMERATED_REGEX = re.compile(r'The list schedule .* is optimal')
-BLOCK_ZERO_TIME_LIMIT = re.compile(r'Bypassing optimal scheduling due to zero time limit')
 BLOCK_ENUMERATED_OPTIMAL_REGEX = re.compile(r'DAG solved optimally')
+BLOCK_ENUMERATED_REGEX = re.compile(r'Enumerating at target length (\d+)')
 BLOCK_COST_LOWER_BOUND_REGEX = re.compile(r'Lower bound of cost before scheduling: (\d+)')
 BLOCK_COST_REGEX = re.compile(r'list schedule is of length \d+ and spill cost \d+. Tot cost = (\d+)')
 BLOCK_IMPROVEMENT_REGEX = re.compile(r'cost imp=(\d+)')
@@ -631,8 +630,7 @@ def calculateBlockStats(output, trackOptSchedSpills):
                 listCost = costLwrBound + int(BLOCK_COST_REGEX.findall(block)[0])
                 # The block is not enumerated if the list schedule is optimal or there is a zero
                 # time limit for enumeration.
-                isEnumerated = (BLOCK_NOT_ENUMERATED_REGEX.findall(block) == []) and (
-                    BLOCK_ZERO_TIME_LIMIT.findall(block) == [])
+                isEnumerated = (BLOCK_ENUMERATED_REGEX.findall(block) != [])
                 if isEnumerated:
                     isOptimal = bool(
                         BLOCK_ENUMERATED_OPTIMAL_REGEX.findall(block))


### PR DESCRIPTION
This patch fixes a bug introduced in #32 which causes the script `runspec-wrapper-optsched.py` to be unable to detect B&B enumeration. Instead of checking for optimality or a timeout of zero, the script now checks for log outputted directly before starting the B&B enumerator.

Tested benchmark: LBM (CPU2006)
```
lbm:
  Blocks: 132
  Successful: 132 (100.00%)
  Enumerated: 10 (7.58%)  992 instrs, 343 spills
```