### PR TITLE
GT: Implement live-range covering (lengthened covered by shortened), plus relaxations

### DIFF
--- a/lib/Scheduler/graph_trans.cpp
+++ b/lib/Scheduler/graph_trans.cpp
@@ -30,8 +30,17 @@ static llvm::SmallVector<const Register *, 10> possiblyLengthenedIfAfterOther(
     const auto usedByC = [&] {
       return llvm::any_of(
           useB->GetUseList(), [&](const SchedInstruction *user) {
+            // Given: [... B ... A ...]
+            // We need to prove that the register `useB` won't be used by an
+            // instruction before A but after B. In the hypothetical schedule we
+            // are considering, A currently appears after B. Thus, it is
+            // sufficient to show that this register has a user C that is a
+            // successor of A.
+            //
+            // This is more relaxed than showing that C is a successor of B, as
+            // RcrsvScsr(B) is a subset of RcrsvScsr(A).
             return user != nodeB &&
-                   nodeB->IsRcrsvScsr(const_cast<SchedInstruction *>(user));
+                   nodeA->IsRcrsvScsr(const_cast<SchedInstruction *>(user));
           });
     };
 


### PR DESCRIPTION
This PR implements live-range covering for the static superiority graph transformations, and it also relaxes the rules to apply graph transformations.

The relaxations:

 - Recursive successor requirement:
   - Old: if B uses R which is not used by A, then R is used by C which is recursive successor of B.
   - New: C is a recursive successor of A. (remember that RcrsvScsr(B) is a subset of RcrsvScsr(A)).
     This is valid because the point is to prove that R is used after the "critical" region, and A is at the end of said region.
 - Covering requirements:
   - We can cover with defs, not just with uses. I implemented this by instead counting the net number of registers whose live ranges were lengthened, subtracting off those whose live ranges were shortened. This yields simpler code overall: 4 vectors became 1.

----

This has been tested on the fp part of CPU2006. Without history domination and with PERP, there are no mismatches.