### PR TITLE
[NFC] Add comments to relevant logs indicating it is used for scripts and fixed a typo.

### DIFF
--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -803,9 +803,8 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds startTime,
 
   for (trgtLngth = schedLwrBound_; trgtLngth <= schedUprBound_; trgtLngth++) {
     InitForSchdulng();
-    //#ifdef IS_DEBUG_ENUM_ITERS
+    // Output used in relevant script:
     Logger::Info("Enumerating at target length %d", trgtLngth);
-    //#endif
     rslt = enumrtr_->FindFeasibleSchedule(enumCrntSched_, trgtLngth, this,
                                           costLwrBound, lngthDeadline);
     if (rslt == RES_TIMEOUT)

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -78,7 +78,7 @@ static bool isBbEnabled(Config &schedIni, Milliseconds rgnTimeout) {
     return false;
 
   if (rgnTimeout <= 0) {
-    Logger::Info("Disabling enumerator becuase region timeout is set to zero.");
+    Logger::Info("Disabling enumerator because region timeout is set to zero.");
     return false;
   }
 
@@ -138,6 +138,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
   Logger::Info("---------------------------------------------------------------"
                "------------");
+  // Output used in relevant script:
   Logger::Info("Processing DAG %s with %d insts and max latency %d.",
                dataDepGraph_->GetDagID(), dataDepGraph_->GetInstCnt(),
                dataDepGraph_->GetMaxLtncy());
@@ -181,6 +182,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   else
     CmputLwrBounds_(false);
 
+  // Output used in relevant script:
   // Log the lower bound on the cost, allowing tools reading the log to compare
   // absolute rather than relative costs.
   Logger::Info("Lower bound of cost before scheduling: %d", costLwrBound_);
@@ -227,11 +229,10 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
     FinishHurstc_();
 
-    //  #ifdef IS_DEBUG_SOLN_DETAILS_1
+    // Output used in relevant script:
     Logger::Info(
         "The list schedule is of length %d and spill cost %d. Tot cost = %d",
         hurstcSchedLngth_, lstSched->GetSpillCost(), hurstcCost_);
-    //  #endif
 
 #ifdef IS_DEBUG_PRINT_SCHEDS
     lstSched->Print(Logger::GetLogStream(), "Heuristic");
@@ -401,12 +402,14 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
           "Bypassing optimal scheduling due to zero time limit with cost %d",
           bestCost_);
     } else {
+      // Output used in relevant script:   
       Logger::Info("The initial schedule of length %d and cost %d is optimal.",
                    bestSchedLngth_, bestCost_);
     }
 
     if (rgnTimeout != 0) {
       bool optimalSchedule = isLstOptml || (rslt == RES_SUCCESS);
+      // Output used in relevant script:
       Logger::Info("Best schedule for DAG %s has cost %d and length %d. The "
                    "schedule is %s",
                    dataDepGraph_->GetDagID(), bestCost_, bestSchedLngth_,
@@ -630,6 +633,7 @@ FUNC_RESULT SchedRegion::Optimize_(Milliseconds startTime,
 
   InstCount imprvmnt = initCost - bestCost_;
   if (rslt == RES_SUCCESS) {
+    // Output used in relevant script:
     Logger::Info("DAG solved optimally in %lld ms with "
                  "length=%d, spill cost = %d, tot cost = %d, cost imp=%d.",
                  solnTime, bestSchedLngth_, bestSched_->GetSpillCost(),
@@ -637,6 +641,7 @@ FUNC_RESULT SchedRegion::Optimize_(Milliseconds startTime,
     stats::solvedProblemSize.Record(dataDepGraph_->GetInstCnt());
     stats::solutionTimeForSolvedProblems.Record(solnTime);
   } else {
+    // Output used in relevant script:
     if (rslt == RES_TIMEOUT) {
       Logger::Info("DAG timed out with "
                    "length=%d, spill cost = %d, tot cost = %d, cost imp=%d.",

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -279,6 +279,7 @@ void ScheduleDAGOptSched::schedule() {
     return;
   }
 
+  // Output used in relevant script:
   Logger::Info("********** Opt Scheduling **********");
   LLVM_DEBUG(dbgs() << "********** Scheduling Region " << RegionName
                     << " **********\n");
@@ -806,6 +807,7 @@ void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
   HeurSchedType = SCHED_LIST;
 
   schedule();
+  // Output used in relevant script:
   Logger::Info("End of first pass through\n");
 }
 
@@ -837,6 +839,7 @@ void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
   MultiPassStaticNodeSup = false;
 
   schedule();
+  // Output used in relevant script:
   Logger::Info("End of second pass through");
 }
 


### PR DESCRIPTION
Add comments documenting whether a log is used in a script and the relevant files. This tries to address #61. 

The relevant files have not yet been added to the comments. I plan on refactoring the scripts so that common regular expressions and functions are in one file to eliminate redundancies.