### PR TITLE
[Enumerator] Fix enumerator not properly updating priorities for dynamic heuristics.

### DIFF
--- a/include/opt-sched/Scheduler/enumerator.h
+++ b/include/opt-sched/Scheduler/enumerator.h
@@ -2,7 +2,7 @@
 Description:  Defines an enumerator class.
 Author:       Ghassan Shobaki
 Created:      Jun. 2002
-Last Update:  Jun. 2017
+Last Update:  Apr. 2020
 *******************************************************************************/
 
 #ifndef OPTSCHED_ENUM_ENUMERATOR_H
@@ -916,6 +916,9 @@ inline void Enumerator::UpdtRdyLst_(InstCount cycleNum, int slotNum) {
   InstCount prevCycleNum = cycleNum - 1;
   LinkedList<SchedInstruction> *lst1 = NULL;
   LinkedList<SchedInstruction> *lst2 = frstRdyLstPerCycle_[cycleNum];
+
+  if (prirts_.isDynmc)
+    rdyLst_->UpdatePriorities();
 
   if (slotNum == 0 && prevCycleNum >= 0) {
     // If at the begining of a new cycle other than the very first cycle, then

--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -4,7 +4,7 @@ Description:  Defines a generic linked list template class with a number of
               Warning: the code within has evolved over many years.
 Author:       Ghassan Shobaki
 Created:      Oct. 1997
-Last Update:  Mar. 2011
+Last Update:  Apr. 2020
 *******************************************************************************/
 
 #ifndef OPTSCHED_GENERIC_LNKD_LST_H
@@ -177,7 +177,9 @@ public:
   T *GetNxtPriorityElmnt();
   T *GetNxtPriorityElmnt(K &key);
   // Copies all the data from another list. The existing list must be empty.
-  void CopyList(PriorityList<T, K> const *const otherLst);
+  // Also insert the entries into an array if it one is passed.
+  void CopyList(PriorityList<T, K> const *const otherLst,
+                KeyedEntry<T, unsigned long> **keyedEntries_ = nullptr);
 
 protected:
   KeyedEntry<T, K> *allocKeyEntries_;
@@ -613,7 +615,9 @@ void PriorityList<T, K>::BoostEntry(KeyedEntry<T, K> *entry, K newKey) {
 }
 
 template <class T, class K>
-void PriorityList<T, K>::CopyList(PriorityList<T, K> const *const otherLst) {
+void PriorityList<T, K>::CopyList(
+    PriorityList<T, K> const *const otherLst,
+    KeyedEntry<T, unsigned long> **keyedEntries_) {
   assert(LinkedList<T>::elmntCnt_ == 0);
 
   for (KeyedEntry<T, K> *entry = (KeyedEntry<T, K> *)otherLst->topEntry_;
@@ -622,6 +626,8 @@ void PriorityList<T, K>::CopyList(PriorityList<T, K> const *const otherLst) {
     K key = entry->key;
     KeyedEntry<T, K> *newEntry = AllocEntry_(elmnt, key);
     LinkedList<T>::AppendEntry_(newEntry);
+    if (keyedEntries_)
+      keyedEntries_[entry->element->GetNum()] = newEntry;
 
     if (entry == otherLst->rtrvEntry_) {
       LinkedList<T>::rtrvEntry_ = newEntry;


### PR DESCRIPTION
The enumerator was not properly updating the priorities for instructions already in the ready list for dynamic heuristics like LUC. New instructions added to the ready list would have the proper priority but their priority does not get updated. This change updates the priorities for all instructions in the ready list when a dynamic heuristic is selected.

Regarding compile time statistics for OptSched, FFT with heuristic `LUC_NID` gained +2 optimal regions found in the second pass. PlaidML saw a -1 to -3 loss in the optimal regions found and +1 to 3 gain in timed out and not improved when using LUC as a first priority heuristic. I believe this is a reasonable tradeoff for the new changes.

No significant regressions were seen in execution-time performance. PlaidML reported a -0.26% to 0.15% difference and SHOC reported a 0.09% to 0.60% difference in geometric scores. Both were within random variation. 