### PR TITLE
Log events as json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /.vscode
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /.vscode
 __pycache__
+*.pyc

--- a/include/opt-sched/Scheduler/logger.h
+++ b/include/opt-sched/Scheduler/logger.h
@@ -10,7 +10,12 @@ Last Update:  Mar. 2011
 #define OPTSCHED_GENERIC_LOGGER_H
 
 #include "opt-sched/Scheduler/defines.h"
-#include <iostream>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iosfwd>
+#include <type_traits>
+#include <utility>
 
 namespace llvm {
 namespace opt_sched {
@@ -52,6 +57,98 @@ void PeriodicLog();
 void Error(const char *format_string, ...);
 void Info(const char *format_string, ...);
 void Summary(const char *format_string, ...);
+
+namespace detail {
+// TODO: When we get C++17, get rid of EventAttrType and EventAttrValue in favor
+// of a std::variant.
+
+/** Encodes the type of an Event attribute */
+enum class EventAttrType {
+  Int64,
+  UInt64,
+  CStr,
+  Bool,
+};
+
+/* Gets the type of the argument */
+inline EventAttrType GetEventAttrType(const char *) {
+  return EventAttrType::CStr;
+}
+
+inline EventAttrType GetEventAttrType(bool) { return EventAttrType::Bool; }
+
+template <typename Int,
+          typename std::enable_if<std::is_integral<Int>::value, int>::type = 0>
+inline EventAttrType GetEventAttrType(Int) {
+  // Treat anything which is not a uint64_t as an int64_t.
+  // This may aid branch prediction in the implementation.
+  return (std::is_signed<Int>::value || sizeof(Int) < sizeof(int64_t))
+             ? EventAttrType::Int64
+             : EventAttrType::UInt64;
+}
+
+/** Encodes the value of an Event attribute. */
+union EventAttrValue {
+  int64_t i64;
+  uint64_t u64;
+  const char *cstr;
+  bool b;
+
+  EventAttrValue(const char *val) : cstr{val} {}
+  EventAttrValue(bool val) : b{val} {}
+
+  template <typename Int, typename std::enable_if<std::is_integral<Int>::value,
+                                                  int>::type = 0>
+  EventAttrValue(Int val) {
+    if (std::is_signed<Int>::value || sizeof(Int) < sizeof(int64_t)) {
+      i64 = val;
+    } else {
+      u64 = val;
+    }
+  }
+};
+
+/** The implementation of Logger::Event(...) */
+void Event(const std::pair<EventAttrType, EventAttrValue> *attrs,
+           size_t numAttrs);
+} // namespace detail
+
+/**
+ * \brief Logs an event in a json format.
+ * \detail
+ *
+ * ``Logger::Event(eventID, [key, value]...)``
+ *
+ * Logs messages of the format `EVENT: {"event_id": eventID, "key": value...}`,
+ * allowing for easier parsing by tools later down the line. The current time is
+ * always included.
+ *
+ * \param eventID a unique ID identifying this event. This should match the
+ * regular expression `[A-Z0-9_]+`. That is, this should contain no spaces.
+ *
+ * \param args An alternating list of keys and values.
+ *
+ * \warning Any change to a log statement of this format requires a change in
+ * our log-parsing scripts.
+ */
+template <typename... Args>
+void Event(const char *eventID, const Args &... args) {
+  static_assert(sizeof...(args) % 2 == 0,
+                "Every key must have a corresponding value.");
+
+  using EventItem = std::pair<detail::EventAttrType, detail::EventAttrValue>;
+
+  std::array<EventItem, sizeof...(args) + 2> arr{
+      EventItem(detail::EventAttrType::CStr,
+                detail::EventAttrValue("event_id")),
+      EventItem(detail::EventAttrType::CStr, detail::EventAttrValue(eventID)),
+      EventItem(detail::GetEventAttrType(args),
+                detail::EventAttrValue(args))...,
+  };
+
+  detail::Event(arr.data(), arr.size());
+}
+
 } // namespace Logger
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/reg_alloc.h
+++ b/include/opt-sched/Scheduler/reg_alloc.h
@@ -47,7 +47,11 @@ public:
   // allocation.
   virtual void PrintSpillInfo(const char *dagName);
   // Return the spill cost of region after register allocation.
-  virtual int GetCost();
+  virtual int GetCost() const;
+  // Return the number of loads
+  int GetNumLoads() const { return numLoads_; }
+  // Return the number of stores
+  int GetNumStores() const { return numStores_; }
 
 private:
   InstSchedule *instSchedule_;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -305,10 +305,10 @@ InstCount BBWithSpill::CmputCostLwrBound() {
       schedLwrBound_ * schedCostFactor_ + spillCostLwrBound * SCW_;
 
 #if defined(IS_DEBUG_STATIC_LOWER_BOUND)
-  Logger::Info(
-      "DAG %s spillCostLB %d scFactor %d lengthLB %d lenFactor %d staticLB %d",
-      dataDepGraph_->GetDagID(), spillCostLwrBound, SCW_, schedLwrBound_,
-      schedCostFactor_, staticLowerBound);
+  Logger::Event("StaticLowerBoundDebugInfo", "name", dataDepGraph_->GetDagID(),
+                "spill_cost_lb", spillCostLwrBound, "sc_factor", SCW_,       //
+                "length_lb", schedLwrBound_, "len_factor", schedCostFactor_, //
+                "static_lb", staticLowerBound);
 #endif
 
   return staticLowerBound;
@@ -790,9 +790,8 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds startTime,
 
   for (trgtLngth = schedLwrBound_; trgtLngth <= schedUprBound_; trgtLngth++) {
     InitForSchdulng();
-    //#ifdef IS_DEBUG_ENUM_ITERS
-    Logger::Info("Enumerating at target length %d", trgtLngth);
-    //#endif
+    Logger::Event("Enumerating", "target_length", trgtLngth);
+
     rslt = enumrtr_->FindFeasibleSchedule(enumCrntSched_, trgtLngth, this,
                                           costLwrBound, lngthDeadline);
     if (rslt == RES_TIMEOUT)

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -2893,6 +2893,9 @@ bool InstSchedule::Verify(MachineModel *machMdl, DataDepGraph *dataDepGraph) {
   Print(std::cout, "debug");
 #endif
 
+  Logger::Event("ScheduleVerifiedSuccessfully");
+  // TODO(justin): Remove once relevant scripts have been updated:
+  // runspec-wrapper-SLIL.py
   Logger::Info("Schedule verified successfully");
 
   return true;

--- a/lib/Scheduler/reg_alloc.cpp
+++ b/lib/Scheduler/reg_alloc.cpp
@@ -278,4 +278,4 @@ void LocalRegAlloc::PrintSpillInfo(const char *dagName) {
   Logger::Info("Number of loads %d", numLoads_);
 }
 
-int LocalRegAlloc::GetCost() { return numLoads_ + numStores_; }
+int LocalRegAlloc::GetCost() const { return numLoads_ + numStores_; }

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -284,6 +284,8 @@ void ScheduleDAGOptSched::schedule() {
     return;
   }
 
+  // This log output is parsed by scripts. Don't change its format unless you
+  // are prepared to change the relevant scripts as well.
   Logger::Info("********** Opt Scheduling **********");
   LLVM_DEBUG(dbgs() << "********** Scheduling Region " << RegionName
                     << " **********\n");
@@ -824,6 +826,10 @@ void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
   HeurSchedType = SCHED_LIST;
 
   schedule();
+  Logger::Event("PassFinished", "num", 1);
+  // TODO(justin): Remove once relevant scripts have been updated:
+  // get-benchmark-stats.py, get-optsched-stats.py, get-sched-length.py,
+  // plaidbench-validation-test.py
   Logger::Info("End of first pass through\n");
 }
 
@@ -855,6 +861,10 @@ void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
   MultiPassStaticNodeSup = false;
 
   schedule();
+  Logger::Event("PassFinished", "num", 2);
+  // TODO(justin): Remove once relevant scripts have been updated:
+  // get-benchmark-stats.py, get-optsched-stats.py, get-sched-length.py,
+  // plaidbench-validation-test.py
   Logger::Info("End of second pass through");
 }
 

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_optsched_unittest(OptSchedBasicTests
-  UtilitiesTest.cpp
   ConfigTest.cpp
+  LoggerTest.cpp
+  UtilitiesTest.cpp
   )

--- a/unittests/Basic/LoggerTest.cpp
+++ b/unittests/Basic/LoggerTest.cpp
@@ -1,0 +1,41 @@
+#include "opt-sched/Scheduler/logger.h"
+
+#include <sstream>
+
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
+
+using namespace llvm::opt_sched;
+
+namespace {
+class LoggerTest : public ::testing::Test {
+protected:
+  LoggerTest() : old{Logger::GetLogStream()} { Logger::SetLogStream(log); }
+
+  ~LoggerTest() override { Logger::SetLogStream(old); }
+
+  std::string getLog() const { return log.str(); }
+
+private:
+  std::ostream &old;
+  std::ostringstream log;
+};
+
+TEST_F(LoggerTest, EventWorks) {
+  Logger::Event("SomeEventID", "key", 42, "key2", "value2", "key3", true,
+                "key4", 123ull, "key5", -123ll);
+  EXPECT_THAT(
+      getLog(),
+      ::testing::MatchesRegex(
+          R"(EVENT: \{"event_id": "SomeEventID", "key": 42, "key2": "value2", "key3": true, "key4": 123, "key5": -123, "time": [0-9]+\})"
+          "\n"));
+}
+
+TEST_F(LoggerTest, EmptyEventIncludesOnlyTime) {
+  Logger::Event("SomeEventID");
+  EXPECT_THAT(getLog(),
+              ::testing::MatchesRegex(
+                  R"(EVENT: \{"event_id": "SomeEventID", "time": [0-9]+\})"
+                  "\n"));
+}
+} // namespace

--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -495,7 +495,7 @@ def calculateBlockStats(output, trackOptSchedSpills):
     blocks = split_blocks(output)
     stats = []
     for index, block in enumerate(blocks):
-        events = parse_as_singular_events(parse_events(block))
+        events = keep_only_first_event(parse_events(block))
 
         try:
             process_dag = events['ProcessDag']

--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -12,6 +12,9 @@ import os
 import shutil
 import pdb
 
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from readlogs import *
+
 ## Configuration
 
 # Dictionary for benchmark selection. Maps benchmark names and categories
@@ -196,21 +199,8 @@ SPILLS_REGEX = re.compile(r'Function: (.*?)\nGREEDY RA: Number of spilled live r
 #SPILLS_REGEX = re.compile(r'Function: (.*?)\nTotal Simulated Spills: (\d+)')
 SPILLS_WEIGHTED_REGEX = re.compile(r'SC in Function (.*?) (-?\d+)')
 TIMES_REGEX = re.compile(r'(\d+) total seconds elapsed')
-BLOCK_NAME_AND_SIZE_REGEX = re.compile(r'Processing DAG (.*) with (\d+) insts')
-BLOCK_ENUMERATED_OPTIMAL_REGEX = re.compile(r'DAG solved optimally')
-BLOCK_ENUMERATED_REGEX = re.compile(r'Enumerating at target length (\d+)')
-BLOCK_COST_LOWER_BOUND_REGEX = re.compile(r'Lower bound of cost before scheduling: (\d+)')
-BLOCK_COST_REGEX = re.compile(r'list schedule is of length \d+ and spill cost \d+. Tot cost = (\d+)')
-BLOCK_IMPROVEMENT_REGEX = re.compile(r'cost imp=(\d+)')
-BLOCK_START_TIME_REGEX = re.compile(r'-{20} \(Time = (\d+) ms\)')
-BLOCK_END_TIME_REGEX = re.compile(r'verified successfully \(Time = (\d+) ms\)')
-BLOCK_LIST_FAILED_REGEX = re.compile(r'List scheduling failed')
-BLOCK_RP_MISMATCH = re.compile(r'RP-mismatch falling back!')
-BLOCK_PEAK_REG_PRESSURE_REGEX = re.compile(r'PeakRegPresAfter Index (\d+) Name (.*) Peak (\d+) Limit (\d+)')
-BLOCK_PEAK_REG_BLOCK_NAME = re.compile(r'LLVM max pressure after scheduling for BB (\S+)')
-REGION_OPTSCHED_SPILLS_REGEX = re.compile(r"OPT_SCHED LOCAL RA: DAG Name: (\S+) Number of spills: (\d+) \(Time")
 
-def writeStats(stats, spills, weighted, times, blocks, regp, trackOptSchedSpills):
+def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
     # Write times.
     if times:
         with open(times, 'w') as times_file:
@@ -500,140 +490,41 @@ def writeStats(stats, spills, weighted, times, blocks, regp, trackOptSchedSpills
             blocks_file.write('  Average optimal solution time: %d ms\n' %
                               ((sum(optimalTimesList) / len(optimalTimesList)) if optimalTimesList else 0))
 
-        # Write peak pressure stats
-        if regp:
-            with open(regp, 'w') as regp_file:
-                for benchName in stats:
-                    regp_file.write('Benchmark %s:\n' % benchName)
-                    regpressure = stats[benchName]['regpressure']
-                    numberOfFunctionsWithPeakExcess = 0
-                    numberOfBlocksWithPeakExcess = 0
-                    numberOfBlocks = 0
-                    peakPressureSetSumsPerBenchmark = {}
-                    for functionName in regpressure:
-                        peakPressureSetSums = {}
-                        regp_file.write('  Function %s:\n' % functionName)
-                        listOfBlocks = regpressure[functionName]
-                        if len(listOfBlocks) == 0:
-                            continue
-                        for blockName, listOfExcessPressureTuples in listOfBlocks:
-                            numberOfBlocks += 1
-                            if len(listOfExcessPressureTuples) == 0:
-                                continue
-                            # regp_file.write('    Block %s:\n' % blockName)
-                            for setName, peakExcessPressure in listOfExcessPressureTuples:
-                                # If we ever enter this loop, that means there exists a peak excess pressure
-                                # regp_file.write('      %5d %s\n' % (peakExcessPressure, setName))
-                                if not setName in peakPressureSetSums:
-                                    peakPressureSetSums[setName] = peakExcessPressure
-                                else:
-                                    peakPressureSetSums[setName] += peakExcessPressure
-                        regp_file.write(
-                            '  Pressure Set Sums for Function %s:\n' % functionName)
-                        for setName in peakPressureSetSums:
-                            regp_file.write('    %5d %s\n' %
-                                            (peakPressureSetSums[setName], setName))
-                            if not setName in peakPressureSetSumsPerBenchmark:
-                                peakPressureSetSumsPerBenchmark[setName] = peakPressureSetSums[setName]
-                            else:
-                                peakPressureSetSumsPerBenchmark[setName] += peakPressureSetSums[setName]
-                    regp_file.write(
-                        'Pressure Set Sums for Benchmark %s:\n' % benchName)
-                    for setName in peakPressureSetSumsPerBenchmark:
-                        regp_file.write('%5d %s\n' % (
-                            peakPressureSetSumsPerBenchmark[setName], setName))
-                    # regp_file.write('Number of blocks with peak excess:    %d\n' % numberOfBlocksWithPeakExcess)
-                    # regp_file.write('Number of blocks total:               %d\n' % numberOfBlocks)
-                    # regp_file.write('Number of functions with peak excess: %d\n' % numberOfFunctionsWithPeakExcess)
-                    # regp_file.write('Number of functions total:            %d\n' % len(regpressure))
-                    regp_file.write('------------\n')
-
-
-def calculatePeakPressureStats(output):
-    """
-    Output should look like:
-    Benchmark:
-      Function1:
-        Block1:
-          PERP1 RegName1
-          PERP2 RegName2
-          ...
-      Function1 Peak: PERPMax RegNameMax
-    Number of blocks with peak excess register pressure: M
-    Number of blocks total: N
-    Number of functions with excess register pressure: F
-    Number of functions total: G
-
-    Then the data structure will look like:
-    {
-      function1: [
-        (block1, [(SetName1, PERP1), ...]),
-        ...
-        ],
-      function2: ...
-    }
-    """
-    blocks = output.split('Scheduling **********')[1:]
-    functions = {}
-    for block in blocks:
-        if len(BLOCK_PEAK_REG_BLOCK_NAME.findall(block)) == 0:
-            continue
-        dagName = BLOCK_PEAK_REG_BLOCK_NAME.findall(block)[0]
-        functionName = dagName.split(':')[0]
-        blockName = dagName.split(':')[1]
-        pressureMatches = BLOCK_PEAK_REG_PRESSURE_REGEX.findall(block)
-        peakExcessPressures = []
-        for indexString, name, peakString, limitString in pressureMatches:
-            peak = int(peakString)
-            limit = int(limitString)
-            excessPressure = peak - limit
-            if excessPressure < 0:
-                excessPressure = 0
-            element = tuple((name, excessPressure))
-            peakExcessPressures.append(element)
-        if len(peakExcessPressures) > 0:
-            blockStats = (blockName, peakExcessPressures)
-            if not functionName in functions:
-                functions[functionName] = []
-            functions[functionName].append(blockStats)
-    return functions
-
 
 def calculateBlockStats(output, trackOptSchedSpills):
-    blocks = output.split('Opt Scheduling **********')[1:]
+    blocks = split_blocks(output)
     stats = []
     for index, block in enumerate(blocks):
-        lines = [line[6:]
-                 for line in block.split('\n') if line.startswith('INFO:')]
-        block = '\n'.join(lines)
+        events = parse_as_singular_events(parse_events(block))
 
         try:
-            name, size = BLOCK_NAME_AND_SIZE_REGEX.findall(block)[0]
+            process_dag = events['ProcessDag']
+            name = process_dag['name']
+            size = process_dag['num_instructions']
 
-            failed = BLOCK_LIST_FAILED_REGEX.findall(
-                block) != [] or BLOCK_RP_MISMATCH.findall(block) != []
+            heuristic_failed = 'HeuristicSchedulerFailed' in events
+            failed = heuristic_failed
 
             if failed:
                 timeTaken = 0
                 isEnumerated = isOptimal = False
                 listCost = improvement = 0
             else:
-                start_time = int(BLOCK_START_TIME_REGEX.findall(block)[0])
-                end_time = int(BLOCK_END_TIME_REGEX.findall(block)[0])
+                start_time = process_dag['time']
+                end_time = events['ScheduleVerifiedSuccessfully']['time']
                 timeTaken = end_time - start_time
-                if REGION_OPTSCHED_SPILLS_REGEX.findall(block) and trackOptSchedSpills:
-                    optSchedSpills = int(REGION_OPTSCHED_SPILLS_REGEX.findall(block)[0][1])
+                if 'LocalRegAllocSimulationChoice' in events and trackOptSchedSpills:
+                    optSchedSpills = events['LocalRegAllocSimulationChoice']['num_spills']
                 else:
                     optSchedSpills = 0
 
-                costLwrBound = int(BLOCK_COST_LOWER_BOUND_REGEX.search(block).group(1))
-                listCost = costLwrBound + int(BLOCK_COST_REGEX.findall(block)[0])
+                costLowerBound = events['CostLowerBound']['cost']
+                listCost = costLowerBound + events['HeuristicResult']['cost']
                 # The block is not enumerated if the list schedule is optimal or there is a zero
                 # time limit for enumeration.
-                isEnumerated = (BLOCK_ENUMERATED_REGEX.findall(block) != [])
+                isEnumerated = 'Enumerating' in events
                 if isEnumerated:
-                    isOptimal = bool(
-                        BLOCK_ENUMERATED_OPTIMAL_REGEX.findall(block))
+                    isOptimal = 'DagSolvedOptimally' in events
                     """
                     Sometimes the OptScheduler doesn't print out cost improvement.
                     This happens when the scheduler determines that the list schedule is
@@ -642,11 +533,7 @@ def calculateBlockStats(output, trackOptSchedSpills):
                     The rest of this if-block ensures that this tool doesn't crash.
                     If the improvement is not found, it is assumed to be 0.
                     """
-                    matches = BLOCK_IMPROVEMENT_REGEX.findall(block)
-                    if matches == []:
-                        improvement = 0
-                    else:
-                        improvement = int(matches[0])
+                    improvement = events['DagSolvedOptimally']['cost_improvement'] if isOptimal else 0
                 else:
                     isOptimal = False
                     improvement = 0
@@ -722,7 +609,6 @@ def getBenchmarkResult(output, trackOptSchedSpills):
         'time': time,
         'spills': calculateSpills(output),
         'blocks': calculateBlockStats(output, trackOptSchedSpills),
-        'regpressure': calculatePeakPressureStats(output)
     }
 
 
@@ -796,13 +682,8 @@ def main(args):
             times = os.path.join(args.outdir, args.times)
             blocks = os.path.join(args.outdir, args.blocks)
 
-            if args.regp:
-                regp = os.path.join(testOutDir, args.regp)
-            else:
-                regp = None
-
             # Write out the results from the logfile.
-            writeStats(results, spills, weighted, times, blocks, regp, args.trackOptSchedSpills)
+            writeStats(results, spills, weighted, times, blocks, args.trackOptSchedSpills)
 
         # Run the benchmarks and collect results.
     else:
@@ -849,13 +730,9 @@ def main(args):
             weighted = os.path.join(testOutDir, args.weighted)
             times = os.path.join(testOutDir, args.times)
             blocks = os.path.join(testOutDir, args.blocks)
-            if args.regp:
-                regp = os.path.join(testOutDir, args.regp)
-            else:
-                regp = None
 
             # Write out the results for this test.
-            writeStats(results, spills, weighted, times, blocks, regp, args.trackOptSchedSpills)
+            writeStats(results, spills, weighted, times, blocks, args.trackOptSchedSpills)
 
 
 if __name__ == '__main__':
@@ -877,9 +754,6 @@ if __name__ == '__main__':
                       metavar='filepath',
                       default='blocks.dat',
                       help='Where to write the run block stats (%default).')
-    parser.add_option('-r', '--regp',
-                      metavar='filepath',
-                      help='Where to write the reg pressure stats (%default).')
     parser.add_option('-c', '--config',
                       metavar='filepath',
                       default='default.cfg',

--- a/util/misc/count-nodes.py
+++ b/util/misc/count-nodes.py
@@ -2,16 +2,17 @@ import re
 import mmap
 import optparse
 import os
+import json
 
-regex = re.compile("Examined (\d+) nodes")
+NODE_COUNT_RE = re.compile(r'EVENT: (.*"event_id": "NodeExamineCount".*)')
 
 def getNodeCount(fileName):
     count = 0
     with open(fileName) as bff:
         bffm = mmap.mmap(bff.fileno(), 0, access=mmap.ACCESS_READ)
 
-        for match in regex.finditer(bffm):
-            count += int(match.group(1))
+        for match in NODE_COUNT_RE.finditer(bffm):
+            count += json.loads(match.group(1))['count']
 
         bffm.close()
 
@@ -25,7 +26,7 @@ parser.add_option('-p', '--path',
                   help='Log file.')
 parser.add_option('--isfolder',
                   action='store_true',
-                  help='Specify if parsing a foldere.')
+                  help='Specify if parsing a folder.')
 
 args = parser.parse_args()[0]
 

--- a/util/misc/extract-script.py
+++ b/util/misc/extract-script.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import argparse
+import os, sys
+import shutil
+import re
+
+parser = argparse.ArgumentParser(
+    description='Extract a standalone version of an OptSched script')
+parser.add_argument(
+    'script', help='The path to script to extract a standalone version of')
+parser.add_argument(
+    'output', help='The output file to write the extracted script to')
+parser.add_argument('--optsched', help='The path to the OptSched directory, '
+                    'if this extract-script.py is not in its original location')
+
+args = parser.parse_args()
+
+OPTSCHED_ROOT = args.optsched if args.optsched else os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+COMMON_FNS = os.path.join(OPTSCHED_ROOT, 'util', 'readlogs', '__init__.py')
+
+with open(args.script, 'r') as f:
+    script = f.read()
+
+with open(COMMON_FNS, 'r') as f:
+    readlogs = f.read()
+
+
+def replace_module(modulename, modulecontent, script):
+    return re.sub(
+        r'^(?:(?:\s*from\s+{0}\s+import.*)|(?:\s*import\s+{0}.*))$'.format(re.escape(modulename)),
+        modulecontent, script, flags=re.MULTILINE)
+
+script = script.replace('sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))\n', '')
+script = replace_module('readlogs', readlogs, script)
+
+if 'readlogs' in script:
+    sys.exit('Failed to make {} standalone. The "readlogs" library couldn\'t be'
+        ' replaced.'.format(args.script))
+
+if os.path.isdir(args.output):
+    # Allow cp-like behavior of "copy to this directory" rather than requiring a
+    # name for the script.
+    output = os.path.join(args.output, os.path.basename(args.script))
+else:
+    output = args.output
+    # Allow placing in a non-existent directory
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+
+with open(output, 'w') as f:
+    f.write(script)
+# Try to keep all permissions
+shutil.copystat(args.script, output)

--- a/util/misc/func-stats.py
+++ b/util/misc/func-stats.py
@@ -3,6 +3,13 @@
 
 import sys
 import re
+import json
+
+def get_events_of_id(logs, event_id):
+    event_start = 'EVENT: {"event_id": "{}"'.format(event_id)
+    lines = logs.splitlines()
+    event_lines = [line.split(' ', 1)[1] for line in lines if line.startswith(event_start)]
+    return list(map(json.loads, event_lines))
 
 RE_NEW_BENCH = re.compile(r'(\d+)\.(.*) base \.exe default')
 RE_BLOCK = re.compile(r'INFO: Processing DAG (.*) with (\d+) insts')
@@ -15,7 +22,7 @@ if __name__ == "__main__":
         totalMismatches = 0
         for line in logfile.readlines():
             matchBench = RE_NEW_BENCH.findall(line)
-            matchBlock = RE_BLOCK.findall(line)
+            matchBlock = get_events_of_id(line)
 
             if matchBench != []:
                 if bench:

--- a/util/misc/spill-compare.py
+++ b/util/misc/spill-compare.py
@@ -3,16 +3,10 @@
 # allocation enabled. Find instances where a reduction in cost does not
 # correspond with a reduction in spills.
 
-import sys
-import re
+import os, sys
 
-RE_REGION_DELIMITER = re.compile(r'INFO: \*{4,}? Opt Scheduling \*{4,}?')
-
-RE_REGION_COST_LOWER_BOUND = re.compile(r'INFO: Lower bound of cost before scheduling: (\d+)')
-RE_REGION_COST_BEST = re.compile(r"INFO: Best schedule for DAG (.*) has cost (\d+) and length (\d+). The schedule is (.*) \(Time")
-RE_REGION_COST_HEURISTIC = re.compile(r"INFO: The list schedule is of length (\d+) and spill cost (\d+). Tot cost = (\d+) \(Time")
-RE_REGION_SPILLS_BEST = re.compile(r"INFO: OPT_SCHED LOCAL RA: DAG Name: (\S+) Number of spills: (\d+) \(Time")
-RE_REGION_SPILLS_HEURISTIC= re.compile(r"INFO: OPT_SCHED LOCAL RA: DAG Name: (.*) \*\*\*heuristic_schedule\*\*\* Number of spills: (\d+) \(Time")
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from readlogs import *
 
 regions = {}
 totalBlocks = 0
@@ -24,38 +18,35 @@ foundRegion = False
 
 with open(str(sys.argv[1])) as logfile:
     log1 = logfile.read()
-    blocks = [block for block in RE_REGION_DELIMITER.split(log1) if RE_REGION_COST_BEST.search(block)]
+    blocks = [block for block in parse_blocks(log1) if 'BestResult' in block]
     for block in blocks:
-        if not RE_REGION_COST_LOWER_BOUND.search(block):
-            print("WARNING: Block does not have a logged lower bound.", out=sys.stderr)
+        if not 'CostLowerBound' not in block:
+            print("WARNING: Block does not have a logged lower bound. Skipping block: " + block,
+                out=sys.stderr)
+            continue
 
         totalBlocks += 1
 
-        lowerBound = int(RE_REGION_COST_LOWER_BOUND.search(block).group(1))
-        regionCostMatchB = RE_REGION_COST_BEST.findall(block)
-        regionName = regionCostMatchB[0][0]
-        regionCostBest = int(regionCostMatchB[0][1])
-        regionLengthBest = int(regionCostMatchB[0][2])
+        lowerBound = block['CostLowerBound']['cost']
+        bestCostInfo = block['BestResult']
+        regionName = bestCostInfo['name']
+        regionCostBest = bestCostInfo['cost']
+        regionLengthBest = bestCostInfo['length']
 
-        if (len(RE_REGION_SPILLS_BEST.findall(block)) == 0):
+        if 'BestLocalRegAllocSimulation' not in block:
             print(regionName)
 
-        regionCostMatchH = RE_REGION_COST_HEURISTIC.findall(block)
-        regionCostHeuristic = int(regionCostMatchH[0][2])
+        regionCostHeuristic = block['HeuristicResult']['spill_cost']
+        regionSpillsBest = block['BestLocalRegAllocSimulation']['num_spills']
+        regionSpillsHeuristic = block['HeuristicLocalRegAllocSimulation']['num_spills']
 
-        regionSpillsMatchB = RE_REGION_SPILLS_BEST.findall(block)
-        regionSpillsBest = int(regionSpillsMatchB[0][1])
-
-        regionSpillsMatchH = RE_REGION_SPILLS_HEURISTIC.findall(block)
-        regionSpillsHeuristic = int(regionSpillsMatchH[0][1])
-
-        if (regionCostBest < regionCostHeuristic and regionSpillsBest > regionSpillsHeuristic):
+        if regionCostBest < regionCostHeuristic and regionSpillsBest > regionSpillsHeuristic:
             totalMismatches+=1
             print("Found Region: "  + regionName + " With Length: " + str(regionLengthBest))
             print("Best Cost: " + str(regionCostBest) + " Heuristic Cost: " + str(regionCostHeuristic))
             print("Best Cost (Absolute): " + (lowerBound + regionCostBest))
             print("Best Spills: " + str(regionSpillsBest) + " Heurisitc Spills: " + str(regionSpillsHeuristic))
-            if (regionLengthBest < lowestLength):
+            if regionLengthBest < lowestLength:
                 foundRegion = True
                 smallestFoundRegion = regionName
                 lowestLength = regionLengthBest

--- a/util/misc/validation-test.py
+++ b/util/misc/validation-test.py
@@ -21,7 +21,7 @@ dags2 = {}
 def dags_info(logtext):
     dags = {}
 
-    unfiltered = parse_blocks(logtext)
+    unfiltered = [keep_only_singular_events(block) for block in parse_blocks(logtext)]
     blocks = [block for block in unfiltered if 'CostLowerBound' in block]
 
     if len(blocks) != len(unfiltered):

--- a/util/readlogs/__init__.py
+++ b/util/readlogs/__init__.py
@@ -30,7 +30,17 @@ def parse_blocks(log):
     '''
     Splits the block into individual blocks and parses each block via parse_events().
     '''
-    return [parse_events(block) for block in log]
+    return [parse_events(block) for block in split_blocks(log)]
+
+def keep_only_singular_events(logs):
+    '''
+    Converts a the event `dict[event_id --> list[event-json]]` to
+    `dict[event_id --> event-json]` dropping any event which has a duplicated event_id.
+    '''
+    result = dict()
+    for k, v in logs.items():
+        if len(v) == 1: result[k] = v[0]
+    return result
 
 def parse_as_singular_events(logs):
     '''

--- a/util/readlogs/__init__.py
+++ b/util/readlogs/__init__.py
@@ -1,0 +1,42 @@
+import json
+
+def split_blocks(log):
+    '''
+    Splits the log into the individual blocks.
+    '''
+    return log.split("INFO: ********** Opt Scheduling **********")[1:]
+
+def parse_events(block_log):
+    '''
+    Returns a `dict[event_id --> list[event-json]]` of the events in the given log.
+
+    `EVENT: {"event_id": "some_id", "value"}`
+    becomes `{"some_id": [{"event_id": "some_id", "arg": "value"}, ...], ...}`
+
+    If there is only one event of each id, pass the result through
+    `parse_as_singular_events(...)` to unwrap the lists.
+    '''
+    lines = block_log.splitlines()
+    event_lines = [line.split(' ', 1)[1] for line in lines if line.startswith('EVENT:')]
+    parsed = list(map(json.loads, event_lines))
+    result = dict()
+
+    for log in parsed:
+        result.setdefault(log['event_id'], []).append(log)
+
+    return result
+
+def parse_blocks(log):
+    '''
+    Splits the block into individual blocks and parses each block via parse_events().
+    '''
+    return [parse_events(block) for block in log]
+
+def parse_as_singular_events(logs):
+    '''
+    Converts a the event `dict[event_id --> list[event-json]]` to
+    `dict[event_id --> event-json]` requiring exactly one event per event_id.
+    '''
+    for k, v in logs.items():
+        if len(v) != 1: raise AssertionError('Duplicate log events for event ' + k)
+    return {k: v[0] for k, v in logs.items()}

--- a/util/readlogs/__init__.py
+++ b/util/readlogs/__init__.py
@@ -42,6 +42,16 @@ def keep_only_singular_events(logs):
         if len(v) == 1: result[k] = v[0]
     return result
 
+def keep_only_first_event(logs):
+    '''
+    Converts a the event `dict[event_id --> list[event-json]]` to
+    `dict[event_id --> event-json]` keeping only the first of any event for a given event_id.
+    '''
+    result = dict()
+    for k, v in logs.items():
+        result[k] = v[0]
+    return result
+
 def parse_as_singular_events(logs):
     '''
     Converts a the event `dict[event_id --> list[event-json]]` to


### PR DESCRIPTION
Currently putting this as a draft PR because it's not complete; I still need to finish going through all the scripts.

I've run into some problems.

 - runspec-wrapper-optsched.py
   - What does `calculatePeakPressureStats` do? I'm unable to find the log command matching `BLOCK_PEAK_REG_BLOCK_NAME` ( "LLVM max pressure after scheduling for BB" ), nor `BLOCK_PEAK_REG_PRESSURE_REGEX`.
   - Which time is `getBenchmarkResult` grabbing? Does it intend to grab the amount of time scheduling took?
      - It seems that it is getting results for blocks which did not go through OptSched, for example:

        ```
        *************************************
        Function: MAIN_finalize
        GREEDY RA: Number of spilled live ranges: 0

        Stores: 0 Reloads: 0 Spill Count: 0
        Stores without cleanup: 0 Reloads without cleanup: 0 Spill Count without cleanup: 0
        Store Cost: 0.000000e+00 Load Cost: 0.000000e+00 Spill Cost: 0

        SC in Function MAIN_finalize 0
        *************************************
        ```

        I actually don't quite understand why we have logs like this. When does this happen instead of OptSched? Is this just for blocks in functions which are not hot (if HOT_ONLY)?

I'll probably have more questions, but this is where I'm at now