### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/include/opt-sched/Scheduler/register.h
+++ b/include/opt-sched/Scheduler/register.h
@@ -69,7 +69,7 @@ public:
   bool IsLiveOut() const;
   void SetIsLiveOut(bool liveOut);
 
-  const Register &operator=(Register &rhs);
+  Register &operator=(const Register &rhs);
 
   void SetupConflicts(int regCnt);
   void ResetConflicts();

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -395,6 +395,7 @@ void ACOScheduler::PrintPheremone() {
 }
 
 #ifndef NDEBUG
+// NOLINTNEXTLINE(clang-diagnostic-unused-function)
 static void PrintInstruction(SchedInstruction *inst) {
   std::cerr << std::setw(2) << inst->GetNum() << " ";
   std::cerr << std::setw(20) << std::left << inst->GetOpCode();

--- a/lib/Scheduler/register.cpp
+++ b/lib/Scheduler/register.cpp
@@ -74,7 +74,7 @@ void Register::IncrmntCrntLngth() { crntLngth_++; }
 
 void Register::DcrmntCrntLngth() { crntLngth_--; }
 
-const Register &Register::operator=(Register &rhs) {
+Register &Register::operator=(const Register &rhs) {
   if (this != &rhs) {
     num_ = rhs.num_;
     type_ = rhs.type_;


### PR DESCRIPTION
#75 has a check which flags these clang-tidy warnings