### PR TITLE
Fix compute critical path bug.

### DIFF
--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -512,7 +512,7 @@ inline UDT_GEDGES GraphNode::GetRcrsvScsrCnt() const {
 }
 
 inline LinkedList<GraphEdge> *GraphNode::GetNghbrLst(DIRECTION dir) {
-  return dir == DIR_FRWRD ? scsrLst_ : prdcsrLst_;
+  return dir == DIR_FRWRD ? prdcsrLst_ : scsrLst_;
 }
 
 inline GraphEdge *GraphNode::GetFrstScsrEdge() {


### PR DESCRIPTION
This patch fixes a crash in debug mode due to a failed [assert](https://github.com/CSUS-LLVM/OptSched/blob/master/lib/Scheduler/sched_basic_data.cpp#L242) when computing the critical path. When computing the critical path, a dir of DIR_FRWD calculates the critical path starting from the root node. To do this, it uses the current critical path of predecessor nodes but we were using the successors instead which returned an invalid value. This was accidentally swapped in #56.

Tested with SPEC CPU2006 and SHOC and this patch fixes the crash in debug mode.