### PR TITLE
Improve GetUses() / GetDefs() to return ArrayRef

### DIFF
--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -8,14 +8,12 @@ Last Update:  Sept. 2013
 #ifndef OPTSCHED_BASIC_SCHED_BASIC_DATA_H
 #define OPTSCHED_BASIC_SCHED_BASIC_DATA_H
 
-// For class string.
-#include <string>
-// For class ostream.
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/graph.h"
 #include "opt-sched/Scheduler/hash_table.h"
 #include "opt-sched/Scheduler/machine_model.h"
-#include <iostream>
+#include "llvm/ADT/ArrayRef.h"
+#include <string>
 
 namespace llvm {
 namespace opt_sched {
@@ -394,15 +392,25 @@ public:
   bool FindDef(Register *reg) const;
   // Returns whether this instruction uses the specified register.
   bool FindUse(Register *reg) const;
-  // Retrieves the list of registers defined by this node. The array is put
-  // into defs and the number of elements is returned.
-  int16_t GetDefs(Register **&defs);
-  // Retrieves the list of registers used by this node. The array is put
-  // into uses and the number of elements is returned.
-  int16_t GetUses(Register **&uses);
 
-  int16_t GetDefCnt() { return defCnt_; }
-  int16_t GetUseCnt() { return useCnt_; }
+  int16_t NumDefs() { return defCnt_; }
+  int16_t NumUses() { return useCnt_; }
+
+  llvm::ArrayRef<Register *> GetDefs() {
+    return llvm::makeArrayRef(defs_, static_cast<size_t>(defCnt_));
+  }
+
+  llvm::ArrayRef<const Register *> GetDefs() const {
+    return llvm::makeArrayRef(defs_, static_cast<size_t>(defCnt_));
+  }
+
+  llvm::ArrayRef<Register *> GetUses() {
+    return llvm::makeArrayRef(uses_, static_cast<size_t>(useCnt_));
+  }
+
+  llvm::ArrayRef<const Register *> GetUses() const {
+    return llvm::makeArrayRef(uses_, static_cast<size_t>(useCnt_));
+  }
 
   // Return the adjusted use count. The number of uses minus live-out uses.
   int16_t GetAdjustedUseCnt() { return adjustedUseCnt_; }

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -401,20 +401,16 @@ static void PrintInstruction(SchedInstruction *inst) {
   std::cerr << std::setw(20) << std::left << inst->GetOpCode();
 
   std::cerr << " defs ";
-  Register **defs;
-  uint16_t defsCount = inst->GetDefs(defs);
-  for (uint16_t i = 0; i < defsCount; i++) {
-    std::cerr << defs[i]->GetNum() << defs[i]->GetType();
-    if (i != defsCount - 1)
+  for (auto def : llvm::enumerate(inst->GetDefs())) {
+    std::cerr << def.value()->GetNum() << def.value()->GetType();
+    if (def.index() != inst->NumDefs() - 1)
       std::cerr << ", ";
   }
 
   std::cerr << " uses ";
-  Register **uses;
-  uint16_t usesCount = inst->GetUses(uses);
-  for (uint16_t i = 0; i < usesCount; i++) {
-    std::cerr << uses[i]->GetNum() << uses[i]->GetType();
-    if (i != usesCount - 1)
+  for (auto use : llvm::enumerate(inst->GetUses())) {
+    std::cerr << use.value()->GetNum() << use.value()->GetType();
+    if (use.index() != inst->NumUses() - 1)
       std::cerr << ", ";
   }
   std::cerr << std::endl;

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -402,16 +402,16 @@ static void PrintInstruction(SchedInstruction *inst) {
 
   std::cerr << " defs ";
   for (auto def : llvm::enumerate(inst->GetDefs())) {
-    std::cerr << def.value()->GetNum() << def.value()->GetType();
-    if (def.index() != inst->NumDefs() - 1)
+    if (def.index() != 0)
       std::cerr << ", ";
+    std::cerr << def.value()->GetNum() << def.value()->GetType();
   }
 
   std::cerr << " uses ";
   for (auto use : llvm::enumerate(inst->GetUses())) {
-    std::cerr << use.value()->GetNum() << use.value()->GetType();
-    if (use.index() != inst->NumUses() - 1)
+    if (use.index() != 0)
       std::cerr << ", ";
+    std::cerr << use.value()->GetNum() << use.value()->GetType();
   }
   std::cerr << std::endl;
 }

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -230,8 +230,8 @@ FUNC_RESULT DataDepGraph::SetupForSchdulng(bool cmputTrnstvClsr) {
     inst->SetMustBeInBBEntry(false);
     inst->SetMustBeInBBExit(false);
 
-    if (inst->GetUseCnt() > maxUseCnt_)
-      maxUseCnt_ = inst->GetUseCnt();
+    if (inst->NumUses() > maxUseCnt_)
+      maxUseCnt_ = inst->NumUses();
   }
 
   //  Logger::Info("Max use count = %d", maxUseCnt_);
@@ -3199,7 +3199,7 @@ bool DataDepGraph::DoesFeedUser(SchedInstruction *inst) {
       continue;
     // Ignore instructions that open more live intervals than
     // it closes because it will increase register pressure instead.
-    else if (curInstAdjUseCnt < succInst->GetDefCnt())
+    else if (curInstAdjUseCnt < succInst->NumDefs())
       continue;
 
     // If there is a successor instruction that decreases live intervals

--- a/lib/Scheduler/graph_trans.cpp
+++ b/lib/Scheduler/graph_trans.cpp
@@ -50,22 +50,6 @@ static llvm::SmallVector<const Register *, 10> possiblyLengthenedIfAfterOther(
   return result;
 }
 
-// Gets the Uses for the given SchedInstruction.
-static llvm::ArrayRef<const Register *> getUses(SchedInstruction *node) {
-  Register **uses;
-  const int useCount = node->GetUses(uses);
-  assert(useCount >= 0);
-  return {uses, static_cast<size_t>(useCount)};
-}
-
-// Gets the Defs for the given SchedInstruction.
-static llvm::ArrayRef<const Register *> getDefs(SchedInstruction *node) {
-  Register **defs;
-  const int defCount = node->GetDefs(defs);
-  assert(defCount >= 0);
-  return {defs, static_cast<size_t>(defCount)};
-}
-
 GraphTrans::GraphTrans(DataDepGraph *dataDepGraph) {
   assert(dataDepGraph != NULL);
 
@@ -242,11 +226,11 @@ bool StaticNodeSupTrans::NodeIsSuperior_(SchedInstruction *nodeA,
   // registers.
   const int regTypes = graph->GetRegTypeCnt();
 
-  const llvm::ArrayRef<const Register *> usesA = ::getUses(nodeA);
-  const llvm::ArrayRef<const Register *> usesB = ::getUses(nodeB);
+  const llvm::ArrayRef<const Register *> usesA = nodeA->GetUses();
+  const llvm::ArrayRef<const Register *> usesB = nodeB->GetUses();
 
-  const llvm::ArrayRef<const Register *> defsA = ::getDefs(nodeA);
-  const llvm::ArrayRef<const Register *> defsB = ::getDefs(nodeB);
+  const llvm::ArrayRef<const Register *> defsA = nodeA->GetDefs();
+  const llvm::ArrayRef<const Register *> defsB = nodeB->GetDefs();
 
   // (# lengthened registers) - (# shortened registers)
   // from scheduling B after A. Indexed by register type.

--- a/lib/Scheduler/ready_list.cpp
+++ b/lib/Scheduler/ready_list.cpp
@@ -174,7 +174,7 @@ unsigned long ReadyList::CmputKey_(SchedInstruction *inst, bool isUpdate,
       break;
 
     case LSH_UC:
-      AddPrirtyToKey_(key, keySize, useCntBits_, inst->GetUseCnt(), maxUseCnt_);
+      AddPrirtyToKey_(key, keySize, useCntBits_, inst->NumUses(), maxUseCnt_);
       break;
 
     case LSH_NID:

--- a/lib/Scheduler/reg_alloc.cpp
+++ b/lib/Scheduler/reg_alloc.cpp
@@ -42,14 +42,8 @@ void LocalRegAlloc::AllocRegs() {
     Logger::Info("REG_ALLOC: Processing instruction %d.", instNum);
 #endif
 
-    Register **uses;
-    Register **defs;
-    int useCnt = inst->GetUses(uses);
-    int defCnt = inst->GetDefs(defs);
-
     // Find registers for this instruction's VReg uses.
-    for (int u = 0; u < useCnt; u++) {
-      Register *use = uses[u];
+    for (Register *use : inst->GetUses()) {
       int16_t regType = use->GetType();
       int virtRegNum = use->GetNum();
       RegMap &map = regMaps_[regType][virtRegNum];
@@ -69,8 +63,7 @@ void LocalRegAlloc::AllocRegs() {
     }
 
     // Kill registers if this is the last use for them.
-    for (int u = 0; u < useCnt; u++) {
-      Register *use = uses[u];
+    for (Register *use : inst->GetUses()) {
       int16_t regType = use->GetType();
       int virtRegNum = use->GetNum();
       RegMap &map = regMaps_[regType][virtRegNum];
@@ -90,8 +83,7 @@ void LocalRegAlloc::AllocRegs() {
     }
 
     // Process definitions.
-    for (int d = 0; d < defCnt; d++) {
-      Register *def = defs[d];
+    for (Register *def : inst->GetDefs()) {
       int16_t regType = def->GetType();
       int virtRegNum = def->GetNum();
 #ifdef IS_DEBUG_REG_ALLOC
@@ -210,14 +202,11 @@ void LocalRegAlloc::ScanUses_() {
       continue;
 
     int instNum = i;
-    Register **uses;
-    int useCnt = inst->GetUses(uses);
 #ifdef IS_DEBUG_REG_ALLOC
     Logger::Info("REG_ALLOC: Scanning for uses for instruction %d.", instNum);
 #endif
 
-    for (int j = 0; j < useCnt; j++) {
-      Register *use = uses[j];
+    for (Register *use : inst->GetUses()) {
       int virtRegNum = use->GetNum();
       int16_t regType = use->GetType();
       if (regMaps_[regType].find(virtRegNum) == regMaps_[regType].end()) {
@@ -245,11 +234,7 @@ void LocalRegAlloc::ScanUses_() {
 
 void LocalRegAlloc::AddLiveIn_(SchedInstruction *artificialEntry) {
   // Process live-in regs.
-  Register **defs;
-  int defCnt = artificialEntry->GetDefs(defs);
-
-  for (int d = 0; d < defCnt; d++) {
-    Register *def = defs[d];
+  for (Register *def : artificialEntry->GetDefs()) {
     int16_t regType = def->GetType();
     int virtRegNum = def->GetNum();
 #ifdef IS_DEBUG_REG_ALLOC


### PR DESCRIPTION
Change GetUses()/GetDefs() to return an llvm::ArrayRef rather than a size and out-param pointer. As a side-effect of this change, many loops over uses or defs have been changed to range-based for loops.

Also, rename `GetUseCnt`/`GetDefCnt` to `NumUses()` and `NumDefs()`.

---

This is the improvement I mentioned in https://github.com/CSUS-LLVM/OptSched/pull/65#issuecomment-612955114