### PR TITLE
Added print spilling patch for flang LLVM7

### DIFF
--- a/patches/llvm7.0/README.md
+++ b/patches/llvm7.0/README.md
@@ -1,0 +1,10 @@
+[![CSUS](http://www.csus.edu/Brand/assets/Logos/Core/Primary/Stacked/Primary_Stacked_3_Color_wht_hndTN.png)](http://www.csus.edu/)
+
+# OptSched - Optimizing Scheduler
+This directory contains patches for LLVM 7.0. These patches must be applied before building LLVM 7.0 to print spilling information.
+
+## Files
+
+`flang-llvm7-print-spilling-info.patch`
+
+This file is for Flang LLVM 7.0 located under the release_70 branch at https://github.com/flang-compiler/llvm.

--- a/patches/llvm7.0/flang-llvm7-print-spilling-info.patch
+++ b/patches/llvm7.0/flang-llvm7-print-spilling-info.patch
@@ -1,0 +1,216 @@
+From ea1d128a9988714cff12d591f7b1f846335ba5f0 Mon Sep 17 00:00:00 2001
+From: Paul McHugh <paulpjmmchugh@gmail.com>
+Date: Mon, 25 May 2020 11:33:41 -0700
+Subject: [PATCH] Patch for adding spilling recording code(flang/llvm7)
+
+---
+ lib/CodeGen/InlineSpiller.cpp  | 66 ++++++++++++++++++++++++++++++++++++++++--
+ lib/CodeGen/RegAllocGreedy.cpp | 37 +++++++++++++++++++++++
+ 2 files changed, 100 insertions(+), 3 deletions(-)
+
+diff --git a/lib/CodeGen/InlineSpiller.cpp b/lib/CodeGen/InlineSpiller.cpp
+index 007e928..8d41402 100644
+--- a/lib/CodeGen/InlineSpiller.cpp
++++ b/lib/CodeGen/InlineSpiller.cpp
+@@ -76,6 +76,15 @@ STATISTIC(NumRemats,          "Number of rematerialized defs for spilling");
+ 
+ static cl::opt<bool> DisableHoisting("disable-spill-hoist", cl::Hidden,
+                                      cl::desc("Disable inline spill hoisting"));
++int NumSpilledRegs = 0;
++int gNumSpilledRanges = 0;
++int gNumSpills = 0;
++int gNumWeightedSpills = 0;
++int gNumReloads = 0;
++int gNumSpillsNoCleanup = 0;
++int gNumReloadsNoCleanup = 0;
++float gWeightedSpills = 0;
++float gWeightedReloads = 0;
+ 
+ namespace {
+ 
+@@ -413,6 +422,11 @@ bool InlineSpiller::hoistSpillInsideBB(LiveInterval &SpillLI,
+   LLVM_DEBUG(dbgs() << "\thoisted: " << SrcVNI->def << '\t' << *MII);
+ 
+   HSpiller.addToMergeableSpills(*MII, StackSlot, Original);
++  gWeightedSpills += LiveIntervals::getSpillWeight(
++      true, false, &MBFI, const_cast<const MachineInstr &>(*MII));
++  ++gNumSpills;
++  ++gNumSpillsNoCleanup;
++  ++NumSpilledRegs;
+   ++NumSpills;
+   return true;
+ }
+@@ -471,8 +485,14 @@ void InlineSpiller::eliminateRedundantSpills(LiveInterval &SLI, VNInfo *VNI) {
+         MI.setDesc(TII.get(TargetOpcode::KILL));
+         DeadDefs.push_back(&MI);
+         ++NumSpillsRemoved;
+-        if (HSpiller.rmFromMergeableSpills(MI, StackSlot))
++        if (HSpiller.rmFromMergeableSpills(MI, StackSlot)) {
+           --NumSpills;
++          --gNumSpills;
++          gWeightedSpills -=
++              LiveIntervals::getSpillWeight(true, false, &MBFI, MI);
++          --NumSpilledRegs;
++          --NumSpills;
++        }
+       }
+     }
+   } while (!WorkList.empty());
+@@ -703,9 +723,16 @@ bool InlineSpiller::coalesceStackAccess(MachineInstr *MI, unsigned Reg) {
+   if (IsLoad) {
+     ++NumReloadsRemoved;
+     --NumReloads;
++    --gNumReloads;
++    gWeightedReloads -= LiveIntervals::getSpillWeight(
++        true, false, &MBFI, const_cast<const MachineInstr &>(*MI));
+   } else {
+     ++NumSpillsRemoved;
+     --NumSpills;
++    --gNumSpills;
++    gWeightedSpills -= LiveIntervals::getSpillWeight(
++        true, false, &MBFI, const_cast<const MachineInstr &>(*MI));
++    --NumSpilledRegs;
+   }
+ 
+   return true;
+@@ -831,8 +858,14 @@ foldMemoryOperand(ArrayRef<std::pair<MachineInstr *, unsigned>> Ops,
+ 
+   int FI;
+   if (TII.isStoreToStackSlot(*MI, FI) &&
+-      HSpiller.rmFromMergeableSpills(*MI, FI))
++      HSpiller.rmFromMergeableSpills(*MI, FI)) {
+     --NumSpills;
++    --gNumSpills;
++    gWeightedSpills -= LiveIntervals::getSpillWeight(
++        true, false, &MBFI, const_cast<const MachineInstr &>(*MI));
++    ++NumSpillsRemoved;
++    --NumSpilledRegs;
++  }
+   LIS.ReplaceMachineInstrInMaps(*MI, *FoldMI);
+   MI->eraseFromParent();
+ 
+@@ -860,9 +893,19 @@ foldMemoryOperand(ArrayRef<std::pair<MachineInstr *, unsigned>> Ops,
+     ++NumFolded;
+   else if (Ops.front().second == 0) {
+     ++NumSpills;
++    ++gNumSpills;
++    ++gNumSpillsNoCleanup;
++    gWeightedSpills += LiveIntervals::getSpillWeight(
++        true, false, &MBFI, const_cast<const MachineInstr &>(*FoldMI));
++    ++NumSpilledRegs;
+     HSpiller.addToMergeableSpills(*FoldMI, StackSlot, Original);
+-  } else
++  } else {
+     ++NumReloads;
++    ++gNumReloads;
++    ++gNumReloadsNoCleanup;
++    gWeightedReloads += LiveIntervals::getSpillWeight(
++        true, false, &MBFI, const_cast<const MachineInstr &>(*FoldMI));
++  }
+   return true;
+ }
+ 
+@@ -920,6 +963,11 @@ void InlineSpiller::insertSpill(unsigned NewVReg, bool isKill,
+   LLVM_DEBUG(dumpMachineInstrRangeWithSlotIndex(std::next(MI), MIS.end(), LIS,
+                                                 "spill"));
+   ++NumSpills;
++  ++gNumSpills;
++  ++gNumSpillsNoCleanup;
++  gWeightedSpills += LiveIntervals::getSpillWeight(
++      true, false, &MBFI, const_cast<const MachineInstr &>(*MI));
++  ++NumSpilledRegs;
+   if (IsRealSpill)
+     HSpiller.addToMergeableSpills(*std::next(MI), StackSlot, Original);
+ }
+@@ -1073,6 +1121,7 @@ void InlineSpiller::spillAll() {
+ }
+ 
+ void InlineSpiller::spill(LiveRangeEdit &edit) {
++  ++gNumSpilledRanges;
+   ++NumSpilledRanges;
+   Edit = &edit;
+   assert(!TargetRegisterInfo::isStackSlot(edit.getReg())
+@@ -1478,11 +1527,22 @@ void HoistSpillHelper::hoistAllSpills() {
+                               MRI.getRegClass(LiveReg), &TRI);
+       LIS.InsertMachineInstrRangeInMaps(std::prev(MI), MI);
+       ++NumSpills;
++      ++gNumSpills;
++      ++NumSpilledRegs;
++      ++gNumSpillsNoCleanup;
++      if (MI != BB->end()) {
++        gWeightedSpills += LiveIntervals::getSpillWeight(
++            true, false, &MBFI, MI->getParent());
++      }
+     }
+ 
+     // Remove redundant spills or change them to dead instructions.
+     NumSpills -= SpillsToRm.size();
++    gNumSpills -= SpillsToRm.size();
++    NumSpilledRegs -= SpillsToRm.size();
+     for (auto const RMEnt : SpillsToRm) {
++      gWeightedSpills -= LiveIntervals::getSpillWeight(
++          true, false, &MBFI, const_cast<const MachineInstr &>(*RMEnt));
+       RMEnt->setDesc(TII.get(TargetOpcode::KILL));
+       for (unsigned i = RMEnt->getNumOperands(); i; --i) {
+         MachineOperand &MO = RMEnt->getOperand(i - 1);
+diff --git a/lib/CodeGen/RegAllocGreedy.cpp b/lib/CodeGen/RegAllocGreedy.cpp
+index 3333e1f..e65d360 100644
+--- a/lib/CodeGen/RegAllocGreedy.cpp
++++ b/lib/CodeGen/RegAllocGreedy.cpp
+@@ -3155,10 +3155,31 @@ void RAGreedy::reportNumberOfSplillsReloads(MachineLoop *L, unsigned &Reloads,
+   }
+ }
+ 
++bool OPTSCHED_gPrintSpills;
++extern int NumSpilledRegs;
++extern int gNumSpilledRanges;
++extern int gNumSpills;
++extern int gNumWeightedSpills;
++extern int gNumReloads;
++extern int gNumSpillsNoCleanup;
++extern int gNumReloadsNoCleanup;
++extern bool gPrintSpills;
++extern float gWeightedSpills;
++extern float gWeightedReloads;
++
+ bool RAGreedy::runOnMachineFunction(MachineFunction &mf) {
+   LLVM_DEBUG(dbgs() << "********** GREEDY REGISTER ALLOCATION **********\n"
+                     << "********** Function: " << mf.getName() << '\n');
+ 
++  NumSpilledRegs = 0;
++  gNumSpills = 0;
++  gNumReloads = 0;
++  gNumSpillsNoCleanup = 0;
++  gNumReloadsNoCleanup = 0;
++  gNumSpilledRanges = 0;
++  gWeightedSpills = 0.0f;
++  gWeightedReloads = 0.0f;
++
+   MF = &mf;
+   TRI = MF->getSubtarget().getRegisterInfo();
+   TII = MF->getSubtarget().getInstrInfo();
+@@ -3210,5 +3231,21 @@ bool RAGreedy::runOnMachineFunction(MachineFunction &mf) {
+   reportNumberOfSplillsReloads();
+ 
+   releaseMemory();
++
++	if (OPTSCHED_gPrintSpills) {
++    std::string fxnName = MF->getFunction().getName().str();
++    long SpillCost = gWeightedSpills + gWeightedReloads;
++    long SpillCount = gNumSpills + gNumReloads;
++    long SpillCountNoCleanup = gNumSpillsNoCleanup + gNumReloadsNoCleanup;
++    dbgs() << "\n*************************************\n";
++    dbgs() << "Function: " << fxnName << "\n";
++    dbgs() << "GREEDY RA: Number of spilled live ranges: " << gNumSpilledRanges << "\n";
++    dbgs() << "\nStores: " << gNumSpills << " Reloads: " << gNumReloads << " Spill Count: " << SpillCount;
++    dbgs() << "\nStores without cleanup: " << gNumSpillsNoCleanup << " Reloads without cleanup: " << gNumReloadsNoCleanup << " Spill Count without cleanup: " << SpillCountNoCleanup;
++    dbgs() << "\nStore Cost: " << gWeightedSpills << " Load Cost: " << gWeightedReloads << " Spill Cost: " << SpillCost << "\n";
++    dbgs() << "\n SC in Function "<< fxnName << " " << SpillCost << "\n";
++    dbgs() << "*************************************\n\n";
++  }
++
+   return true;
+ }
+-- 
+2.7.4
+


### PR DESCRIPTION
This is the patch that is needed to compile flang LLVM7 with spilling info printing.

I am using flang LLVM7 (LLVM 7 is the last version old flang supports) for the ACO paper, so I modified the flang LLVM6 patch so I can get spilling info for this version.  