### PR TITLE
Fix setting LLVM_MUTATIONS option to YES does not enable mutations

### DIFF
--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -46,12 +46,6 @@ ScheduleDAGOptSchedGCN::ScheduleDAGOptSchedGCN(
     : ScheduleDAGOptSched(C, std::move(S)) {}
 
 void ScheduleDAGOptSchedGCN::initSchedulers() {
-  // Add DAG mutations that apply to both GCN and OptSched DAG's
-
-  addMutation(createLoadClusterDAGMutation(TII, TRI));
-  addMutation(createStoreClusterDAGMutation(TII, TRI));
-  // addMutation(createAMDGPUMacroFusionDAGMutation());
-
   // Add passes
 
   // SchedPasses.push_back(GCNMaxOcc);
@@ -61,6 +55,16 @@ void ScheduleDAGOptSchedGCN::initSchedulers() {
   // Second
   SchedPasses.push_back(OptSchedBalanced);
 }
+
+// Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+void ScheduleDAGOptSchedGCN::addLLVMMutations() {
+  // Add DAG mutations that apply to both GCN and OptSched DAG's
+
+  addMutation(createLoadClusterDAGMutation(TII, TRI));
+  addMutation(createStoreClusterDAGMutation(TII, TRI));
+  // addMutation(createAMDGPUMacroFusionDAGMutation());
+}
+
 
 // Execute scheduling passes.
 // Partially copied GCNScheduleDAGMILive::finalizeSchedule

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -56,7 +56,7 @@ void ScheduleDAGOptSchedGCN::initSchedulers() {
   SchedPasses.push_back(OptSchedBalanced);
 }
 
-// Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+// Add the appropriate LLVM mutations.
 void ScheduleDAGOptSchedGCN::addLLVMMutations() {
   // Add DAG mutations that apply to both GCN and OptSched DAG's
 

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -60,9 +60,11 @@ void ScheduleDAGOptSchedGCN::initSchedulers() {
 void ScheduleDAGOptSchedGCN::addLLVMMutations() {
   // Add DAG mutations that apply to both GCN and OptSched DAG's
 
-  addMutation(createLoadClusterDAGMutation(TII, TRI));
-  addMutation(createStoreClusterDAGMutation(TII, TRI));
-  // addMutation(createAMDGPUMacroFusionDAGMutation());
+  if (EnableMutations) {
+    addMutation(createLoadClusterDAGMutation(TII, TRI));
+    addMutation(createStoreClusterDAGMutation(TII, TRI));
+    // addMutation(createAMDGPUMacroFusionDAGMutation());
+  }
 }
 
 // Execute scheduling passes.

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -65,7 +65,6 @@ void ScheduleDAGOptSchedGCN::addLLVMMutations() {
   // addMutation(createAMDGPUMacroFusionDAGMutation());
 }
 
-
 // Execute scheduling passes.
 // Partially copied GCNScheduleDAGMILive::finalizeSchedule
 void ScheduleDAGOptSchedGCN::finalizeSchedule() {

--- a/lib/Wrapper/AMDGPU/GCNOptSched.h
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.h
@@ -31,6 +31,9 @@ public:
   // Setup and select schedulers.
   void initSchedulers() override;
 
+  // Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+  void addLLVMMutations() override;
+
   // TODO: After we refactor OptSched scheduler options put each scheduling
   // pass into its own class.
 

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -218,8 +218,7 @@ ScheduleDAGOptSched::ScheduleDAGOptSched(
   MM->convertMachineModel(static_cast<ScheduleDAGInstrs &>(*this),
                           RegClassInfo);
 
-  if (EnableMutations)
-    addLLVMMutations();
+  addLLVMMutations();
 }
 
 void ScheduleDAGOptSched::SetupLLVMDag() {
@@ -249,13 +248,17 @@ void ScheduleDAGOptSched::initSchedulers() {
   SchedPasses.push_back(OptSchedBalanced);
 }
 
-// Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+// Add the appropriate LLVM mutations.
 void ScheduleDAGOptSched::addLLVMMutations() {
-  addMutation(createCopyConstrainDAGMutation(TII, TRI));
-  // README: if you need the x86 mutations uncomment the next line.
-  // addMutation(createX86MacroFusionDAGMutation());
-  // You also need to add the next line somewhere above this function
-  //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
+
+  // Adds the LLVM mutations if LLVM_MUTATIONS is set
+  if (EnableMutations) {
+    addMutation(createCopyConstrainDAGMutation(TII, TRI));
+    // README: if you need the x86 mutations uncomment the next line.
+    // addMutation(createX86MacroFusionDAGMutation());
+    // You also need to add the next line somewhere above this function
+    //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
+  }
 }
 
 // schedule called for each basic block

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -238,9 +238,9 @@ void ScheduleDAGOptSched::SetupLLVMDag() {
   // Apply llvm DAG post processing.
   if (EnableMutations) {
     addMutation(createCopyConstrainDAGMutation(TII, TRI));
-    //README: if you need the x86 mutations uncomment the next line.
-    //addMutation(createX86MacroFusionDAGMutation());
-    //You also need to add the next line somewhere above this function
+    // README: if you need the x86 mutations uncomment the next line.
+    // addMutation(createX86MacroFusionDAGMutation());
+    // You also need to add the next line somewhere above this function
     //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
     Topo.InitDAGTopologicalSorting();
     postprocessDAG();

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -218,7 +218,7 @@ ScheduleDAGOptSched::ScheduleDAGOptSched(
   MM->convertMachineModel(static_cast<ScheduleDAGInstrs &>(*this),
                           RegClassInfo);
 
-  if(EnableMutations)
+  if (EnableMutations)
     addLLVMMutations();
 }
 
@@ -237,7 +237,6 @@ void ScheduleDAGOptSched::SetupLLVMDag() {
 
   // Finalize live-in
   RPTracker.closeTop();
-
 }
 
 // Add the two passes used for the two pass scheduling approach
@@ -252,11 +251,11 @@ void ScheduleDAGOptSched::initSchedulers() {
 
 // Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
 void ScheduleDAGOptSched::addLLVMMutations() {
-    addMutation(createCopyConstrainDAGMutation(TII, TRI));
-    // README: if you need the x86 mutations uncomment the next line.
-    // addMutation(createX86MacroFusionDAGMutation());
-    // You also need to add the next line somewhere above this function
-    //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
+  addMutation(createCopyConstrainDAGMutation(TII, TRI));
+  // README: if you need the x86 mutations uncomment the next line.
+  // addMutation(createX86MacroFusionDAGMutation());
+  // You also need to add the next line somewhere above this function
+  //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
 }
 
 // schedule called for each basic block

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -237,6 +237,11 @@ void ScheduleDAGOptSched::SetupLLVMDag() {
 
   // Apply llvm DAG post processing.
   if (EnableMutations) {
+    addMutation(createCopyConstrainDAGMutation(TII, TRI));
+    //README: if you need the x86 mutations uncomment the next line.
+    //addMutation(createX86MacroFusionDAGMutation());
+    //You also need to add the next line somewhere above this function
+    //#include "../../../../../llvm/lib/Target/X86/X86MacroFusion.h"
     Topo.InitDAGTopologicalSorting();
     postprocessDAG();
   }
@@ -275,6 +280,8 @@ void ScheduleDAGOptSched::schedule() {
 
   if (!OptSchedEnabled || !scheduleSpecificRegion(RegionName, schedIni)) {
     LLVM_DEBUG(dbgs() << "Skipping region " << RegionName << "\n");
+    SetupLLVMDag();
+    ScheduleDAGMILive::schedule();
     return;
   }
 
@@ -296,6 +303,7 @@ void ScheduleDAGOptSched::schedule() {
 
   // Use LLVM's heuristic schedule as input to the B&B scheduler.
   if (UseLLVMScheduler) {
+    SetupLLVMDag();
     ScheduleDAGMILive::schedule();
 
     OriginalDAG = SUnits;

--- a/lib/Wrapper/OptimizingScheduler.h
+++ b/lib/Wrapper/OptimizingScheduler.h
@@ -236,7 +236,7 @@ public:
   // Setup and select schedulers for the two pass scheduling approach.
   virtual void initSchedulers();
 
-  // Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+  // Add the appropriate LLVM mutations.
   virtual void addLLVMMutations();
 
   // Execute a scheduling pass on the function.

--- a/lib/Wrapper/OptimizingScheduler.h
+++ b/lib/Wrapper/OptimizingScheduler.h
@@ -236,6 +236,9 @@ public:
   // Setup and select schedulers for the two pass scheduling approach.
   virtual void initSchedulers();
 
+  // Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
+  virtual void addLLVMMutations();
+
   // Execute a scheduling pass on the function.
   void runSchedPass(SchedPassStrategy S);
 


### PR DESCRIPTION
When the default machine instruction scheduler ScheduleDAGMILive is created LLVM adds a generic mutation see
https://github.com/llvm/llvm-project/blob/release/7.x/llvm/lib/CodeGen/MachineScheduler.cpp#L3193
When the ScheduleDAGOptSched (our subclass of ScheduleDAGMILive) is created no mutations are
added.  Our option in sched.ini LLVM_MUTATIONS is supposed to add the generic mutations to our scheduler.  It does currently only calls the function which applies the mutations that have already been added.  It does not actually add the mutation in question.  This commit fixes the issue.