### PR TITLE
Fix dag mutations

### DIFF
--- a/include/opt-sched/Scheduler/OptSchedDDGWrapperBase.h
+++ b/include/opt-sched/Scheduler/OptSchedDDGWrapperBase.h
@@ -14,7 +14,7 @@ class OptSchedDDGWrapperBase {
 public:
   virtual ~OptSchedDDGWrapperBase() = default;
 
-  virtual void convertSUnits() = 0;
+  virtual void convertSUnits(bool IgnoreArtificialEdges = false) = 0;
 
   virtual void convertRegFiles() = 0;
 };

--- a/include/opt-sched/Scheduler/OptSchedDDGWrapperBase.h
+++ b/include/opt-sched/Scheduler/OptSchedDDGWrapperBase.h
@@ -14,7 +14,8 @@ class OptSchedDDGWrapperBase {
 public:
   virtual ~OptSchedDDGWrapperBase() = default;
 
-  virtual void convertSUnits(bool IgnoreArtificialEdges = false) = 0;
+  virtual void convertSUnits(bool IgnoreRealEdges,
+                             bool IgnoreArtificialEdges) = 0;
 
   virtual void convertRegFiles() = 0;
 };

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -391,7 +391,7 @@ protected:
                                 InstCount fileUB, int blkNum);
   FUNC_RESULT FinishNode_(InstCount nodeNum, InstCount edgeCnt = -1);
   void CreateEdge_(InstCount frmInstNum, InstCount toInstNum, int ltncy,
-                   DependenceType depType);
+                   DependenceType depType, bool IsArtificial = false);
 
   FUNC_RESULT Finish_();
 

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -49,11 +49,15 @@ struct GraphEdge {
   UDT_GEDGES predOrder;
   // The second node's order in the first node's successor list.
   UDT_GEDGES succOrder;
+  // Whether or not the edge is an artificial dependency meaning it isn't
+  // required to be correct
+  bool IsArtificial;
 
   // Creates an edge between two nodes with labels label and label2.
   GraphEdge(GraphNode *from, GraphNode *to, UDT_GLABEL label,
-            UDT_GLABEL label2 = 0)
-      : from(from), to(to), label(label), label2(label2) {}
+            UDT_GLABEL label2 = 0, bool IsArtificial = false)
+      : from(from), to(to), label(label), label2(label2),
+        IsArtificial(IsArtificial) {}
 
   // Returns the node on the other side of the edge from the provided node.
   // Assumes that the argument is one of the nodes on the sides of the edge.

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -202,12 +202,14 @@ public:
   //   depType: the type of dependence between this node and the successor.
   SchedInstruction *GetFrstScsr(InstCount *prdcsrNum = NULL,
                                 UDT_GLABEL *ltncy = NULL,
-                                DependenceType *depType = NULL);
+                                DependenceType *depType = NULL,
+                                bool *IsArtificial = nullptr);
   // Returns the next successor of this instruction node and moves the
   // successor iterator forward. Fills parameters as above.
   SchedInstruction *GetNxtScsr(InstCount *prdcsrNum = NULL,
                                UDT_GLABEL *ltncy = NULL,
-                               DependenceType *depType = NULL);
+                               DependenceType *depType = NULL,
+                               bool *IsArtificial = nullptr);
 
   // Returns the last successor of this instruction node and moves the
   // successor iterator to the end of the list. If prdcsrNum is provided, this

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -2978,7 +2978,7 @@ bool InstSchedule::VerifyDataDeps_(DataDepGraph *dataDepGraph) {
              inst->GetFrstScsr(NULL, &ltncy, &depType, &IsArtificial);
          scsr != NULL;
          scsr = inst->GetNxtScsr(NULL, &ltncy, &depType, &IsArtificial)) {
-      // Artificial nodes are not required for the schedule to be correct
+      // Artificial edges are not required for the schedule to be correct
       if (IsArtificial)
         continue;
 

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -350,7 +350,8 @@ SchedInstruction *SchedInstruction::GetNxtPrdcsr(InstCount *scsrNum,
 
 SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
                                                 UDT_GLABEL *ltncy,
-                                                DependenceType *depType) {
+                                                DependenceType *depType,
+                                                bool *IsArtificial) {
   GraphEdge *edge = GetFrstScsrEdge();
   if (!edge)
     return NULL;
@@ -360,12 +361,15 @@ SchedInstruction *SchedInstruction::GetFrstScsr(InstCount *prdcsrNum,
     *ltncy = edge->label;
   if (depType)
     *depType = (DependenceType)edge->label2;
+  if (IsArtificial)
+    *IsArtificial = edge->IsArtificial;
   return (SchedInstruction *)(edge->to);
 }
 
 SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
                                                UDT_GLABEL *ltncy,
-                                               DependenceType *depType) {
+                                               DependenceType *depType,
+                                               bool *IsArtificial) {
   GraphEdge *edge = GetNxtScsrEdge();
   if (!edge)
     return NULL;
@@ -375,6 +379,8 @@ SchedInstruction *SchedInstruction::GetNxtScsr(InstCount *prdcsrNum,
     *ltncy = edge->label;
   if (depType)
     *depType = (DependenceType)edge->label2;
+  if (IsArtificial)
+    *IsArtificial = edge->IsArtificial;
   return (SchedInstruction *)(edge->to);
 }
 

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -200,7 +200,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     stats::heuristicTime.Record(hurstcTime);
     if (hurstcTime > 0)
       Logger::Info("Heuristic_Time %d", hurstcTime);
-
   }
 
   // After the sequential scheduler in the second pass, add the artificial edges
@@ -257,7 +256,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
                                   "CP Lower Bounds");
 #endif
   }
-
 
   // Log the lower bound on the cost, allowing tools reading the log to compare
   // absolute rather than relative costs.

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -244,6 +244,16 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 #endif
   }
 
+  if (isSecondPass()) {
+    auto *BDDG = static_cast<OptSchedDDGWrapperBasic *> dataDepGraph;
+    BDDG->addArtificialEdges();
+    rslt = dataDepGraph_->UpdateSetupForSchdulng(needTransitiveClosure);
+    if (rslt != RES_SUCCESS) {
+      Logger::Info("Invalid DAG after adding artificial cluster edges");
+      return rslt;
+    }
+  }
+
   // Step #2: Use ACO to find a schedule if enabled and no optimal schedule is
   // yet to be found.
   if (AcoBeforeEnum && !isLstOptml) {

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -177,17 +177,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   CmputAbslutUprBound_();
   schedLwrBound_ = dataDepGraph_->GetSchedLwrBound();
 
-  // We can calculate lower bounds here since it is only dependent
-  // on schedLwrBound_
-  if (!BbSchedulerEnabled)
-    costLwrBound_ = CmputCostLwrBound();
-  else
-    CmputLwrBounds_(false);
-
-  // Log the lower bound on the cost, allowing tools reading the log to compare
-  // absolute rather than relative costs.
-  Logger::Info("Lower bound of cost before scheduling: %d", costLwrBound_);
-
   // Step #1: Find the heuristic schedule if enabled.
   // Note: Heuristic scheduler is required for the two-pass scheduler
   // to use the sequential list scheduler which inserts stalls into
@@ -257,6 +246,17 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
       return rslt;
     }
   }
+
+  // This must be done after SetupForSchdulng() or UpdateSetupForSchdulng() to
+  // avoid resetting lower bound values.
+  if (!BbSchedulerEnabled)
+    costLwrBound_ = CmputCostLwrBound();
+  else
+    CmputLwrBounds_(false);
+
+  // Log the lower bound on the cost, allowing tools reading the log to compare
+  // absolute rather than relative costs.
+  Logger::Info("Lower bound of cost before scheduling: %d", costLwrBound_);
 
   // Step #2: Use ACO to find a schedule if enabled and no optimal schedule is
   // yet to be found.

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -14,6 +14,7 @@
 #include "opt-sched/Scheduler/sched_region.h"
 #include "opt-sched/Scheduler/stats.h"
 #include "opt-sched/Scheduler/utilities.h"
+#include "Wrapper/OptSchedDDGWrapperBasic.h"
 
 extern bool OPTSCHED_gPrintSpills;
 
@@ -244,9 +245,12 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 #endif
   }
 
-  if (isSecondPass()) {
-    auto *BDDG = static_cast<OptSchedDDGWrapperBasic *> dataDepGraph;
-    BDDG->addArtificialEdges();
+  // After the sequential scheduler in the second pass, add the artificial edges
+  // to the DDG. Some mutations were adding artificial edges which caused a
+  // conflict with the sequential scheduler. Therefore, wait until the
+  // sequential scheduler is done before adding artificial edges.
+  if (IsSecondPass()) {
+    static_cast<OptSchedDDGWrapperBasic *>(dataDepGraph_)->addArtificialEdges();
     rslt = dataDepGraph_->UpdateSetupForSchdulng(needTransitiveClosure);
     if (rslt != RES_SUCCESS) {
       Logger::Info("Invalid DAG after adding artificial cluster edges");

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -2,6 +2,7 @@
 #include <memory>
 #include <utility>
 
+#include "Wrapper/OptSchedDDGWrapperBasic.h"
 #include "opt-sched/Scheduler/aco.h"
 #include "opt-sched/Scheduler/bb_spill.h"
 #include "opt-sched/Scheduler/config.h"
@@ -14,7 +15,6 @@
 #include "opt-sched/Scheduler/sched_region.h"
 #include "opt-sched/Scheduler/stats.h"
 #include "opt-sched/Scheduler/utilities.h"
-#include "Wrapper/OptSchedDDGWrapperBasic.h"
 
 extern bool OPTSCHED_gPrintSpills;
 

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
@@ -455,7 +455,8 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
     else
       Latency = 1; // unit latency = ignore ilp
 
-    CreateEdge_(SU.NodeNum, I->getSUnit()->NodeNum, Latency, DepType);
+    CreateEdge_(SU.NodeNum, I->getSUnit()->NodeNum, Latency, DepType,
+                IsArtificial);
   }
 }
 

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.h
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.h
@@ -47,7 +47,8 @@ public:
   /// Dump Optsched register def/use information for the region.
   void dumpOptSchedRegisters() const;
 
-  void convertSUnits() override;
+  void convertSUnits(bool IgnoreArtificialEdges = false) override;
+  void addArtificialEdges();
   void convertRegFiles() override;
 
 protected:
@@ -123,7 +124,7 @@ protected:
   void convertSUnit(const llvm::SUnit &SU);
 
   // Create edges between optsched graph nodes using SUnit successors.
-  void convertEdges(const llvm::SUnit &SU);
+  void convertEdges(const llvm::SUnit &SU, bool IgnoreArtificialEdges = false);
 
   // Count number or registers defined by the region boundary.
   void countBoundaryLiveness(std::vector<int> &RegDefCounts,
@@ -143,9 +144,9 @@ protected:
 };
 
 // Exclude certain registers from being visible to the scheduler. Use LLVM's
-// register pressure tracker to find the MAX register pressure for each register
-// type (pressure set). If the MAX pressure is below a certain threshold don't
-// track that register.
+// register pressure tracker to find the MAX register pressure for each
+// register type (pressure set). If the MAX pressure is below a certain
+// threshold don't track that register.
 class LLVMRegTypeFilter {
 private:
   const MachineModel *MM;
@@ -166,13 +167,13 @@ public:
   ~LLVMRegTypeFilter() = default;
 
   // The proportion of the register pressure set limit that a register's Max
-  // pressure must be higher than in order to not be filtered out. (default .7)
-  // The idea is that there is no point in trying to reduce the register
+  // pressure must be higher than in order to not be filtered out. (default
+  // .7) The idea is that there is no point in trying to reduce the register
   // pressure
   // of a register type that is in no danger of causing spilling. If the
   // RegFilterFactor is .7, and a random register type has a pressure limit of
-  // 10, then we filter out the register types if the MAX pressure for that type
-  // is below 7. (10 * .7 = 7)
+  // 10, then we filter out the register types if the MAX pressure for that
+  // type is below 7. (10 * .7 = 7)
   void setRegFilterFactor(float RegFilterFactor);
 
   // Return true if this register type should be filtered out.

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.h
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.h
@@ -47,7 +47,7 @@ public:
   /// Dump Optsched register def/use information for the region.
   void dumpOptSchedRegisters() const;
 
-  void convertSUnits(bool IgnoreArtificialEdges = false) override;
+  void convertSUnits(bool IgnoreRealEdges, bool IgnoreArtificialEdges) override;
   void addArtificialEdges();
   void convertRegFiles() override;
 
@@ -124,7 +124,8 @@ protected:
   void convertSUnit(const llvm::SUnit &SU);
 
   // Create edges between optsched graph nodes using SUnit successors.
-  void convertEdges(const llvm::SUnit &SU, bool IgnoreArtificialEdges = false);
+  void convertEdges(const llvm::SUnit &SU, bool IgnoreRealEdges,
+                    bool IgnoreArtificialEdges);
 
   // Count number or registers defined by the region boundary.
   void countBoundaryLiveness(std::vector<int> &RegDefCounts,

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -377,7 +377,14 @@ void ScheduleDAGOptSched::schedule() {
   // Convert graph
   auto DDG =
       OST->createDDGWrapper(C, this, MM.get(), LatencyPrecision, RegionName);
-  DDG->convertSUnits();
+
+  // In the second pass, ignore artificial edges before running the sequential
+  // heuristic list scheduler.
+  if (SecondPass)
+    DDG->convertSUnits(false, true);
+  else
+    DDG->convertSUnits(false, false);
+
   DDG->convertRegFiles();
 
   auto *BDDG = static_cast<OptSchedDDGWrapperBasic *>(DDG.get());


### PR DESCRIPTION
There was an issue with the sequential heuristic list scheduler and LLVM mutations in the second pass. This fix postpones adding the artificial edges from the mutations until after the sequential heuristic list scheduler is finished.