### PR TITLE
Fix mismatched new/delete

### DIFF
--- a/include/opt-sched/Scheduler/ready_list.h
+++ b/include/opt-sched/Scheduler/ready_list.h
@@ -15,6 +15,7 @@ Last Update:  Sept. 2013
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/lnkd_lst.h"
 #include "opt-sched/Scheduler/sched_basic_data.h"
+#include "llvm/ADT/SmallVector.h"
 #include <cstdio>
 
 namespace llvm {
@@ -87,13 +88,14 @@ private:
   SchedPriorities prirts_;
 
   // The priority list containing the actual instructions.
-  PriorityList<SchedInstruction> *prirtyLst_;
+  PriorityList<SchedInstruction> prirtyLst_;
 
   // TODO(max): Document.
-  LinkedList<SchedInstruction> *latestSubLst_;
+  LinkedList<SchedInstruction> latestSubLst_;
 
   // Array of pointers to KeyedEntry objects
-  KeyedEntry<SchedInstruction, unsigned long> **keyedEntries_;
+  llvm::SmallVector<KeyedEntry<SchedInstruction, unsigned long> *, 0>
+      keyedEntries_;
 
   // Is there a priority scheme that needs to be changed dynamically
   //    bool isDynmcPrirty_;

--- a/lib/Scheduler/ready_list.cpp
+++ b/lib/Scheduler/ready_list.cpp
@@ -127,9 +127,8 @@ void ReadyList::CopyList(ReadyList *otherList) {
   assert(otherList != NULL);
 
   // Copy the ready list and create the array of keyed entries. If a dynamic
-  // heuristic is not used then the second parameter should be a nullptr and the
-  // array will not be created.
-  prirtyLst_.CopyList(&otherList->prirtyLst_, keyedEntries_.data());
+  // heuristic is not used then the second parameter should be an empty array.
+  prirtyLst_.CopyList(&otherList->prirtyLst_, keyedEntries_);
 }
 
 unsigned long ReadyList::CmputKey_(SchedInstruction *inst, bool isUpdate,

--- a/lib/Scheduler/ready_list.cpp
+++ b/lib/Scheduler/ready_list.cpp
@@ -7,17 +7,14 @@ using namespace llvm::opt_sched;
 
 ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts) {
   prirts_ = prirts;
-  prirtyLst_ = NULL;
   int i;
   uint16_t totKeyBits = 0;
 
   // Initialize an array of KeyedEntry if a dynamic heuristic is used. This
   // enable fast updating for dynamic heuristics.
-  if (prirts_.isDynmc)
-    keyedEntries_ = new KeyedEntry<SchedInstruction, unsigned long>
-        *[dataDepGraph->GetInstCnt()];
-  else
-    keyedEntries_ = nullptr;
+  if (prirts_.isDynmc) {
+    keyedEntries_.resize(dataDepGraph->GetInstCnt());
+  }
 
   useCntBits_ = crtclPathBits_ = scsrCntBits_ = ltncySumBits_ = nodeID_Bits_ =
       inptSchedOrderBits_ = 0;
@@ -82,9 +79,6 @@ ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts) {
   Logger::Info("The ready list key size is %d bits", totKeyBits);
 #endif
 
-  prirtyLst_ = new PriorityList<SchedInstruction>;
-  latestSubLst_ = new LinkedList<SchedInstruction>;
-
   int16_t keySize = 0;
   maxPriority_ = 0;
   for (i = 0; i < prirts_.cnt; i++) {
@@ -120,30 +114,22 @@ ReadyList::ReadyList(DataDepGraph *dataDepGraph, SchedPriorities prirts) {
   }
 }
 
-ReadyList::~ReadyList() {
-  Reset();
-  if (prirtyLst_)
-    delete prirtyLst_;
-  if (latestSubLst_)
-    delete latestSubLst_;
-  if (keyedEntries_)
-    delete keyedEntries_;
-}
+ReadyList::~ReadyList() { Reset(); }
 
 void ReadyList::Reset() {
-  prirtyLst_->Reset();
-  latestSubLst_->Reset();
+  prirtyLst_.Reset();
+  latestSubLst_.Reset();
 }
 
-void ReadyList::CopyList(ReadyList *othrLst) {
-  assert(prirtyLst_->GetElmntCnt() == 0);
-  assert(latestSubLst_->GetElmntCnt() == 0);
-  assert(othrLst != NULL);
+void ReadyList::CopyList(ReadyList *otherList) {
+  assert(prirtyLst_.GetElmntCnt() == 0);
+  assert(latestSubLst_.GetElmntCnt() == 0);
+  assert(otherList != NULL);
 
   // Copy the ready list and create the array of keyed entries. If a dynamic
   // heuristic is not used then the second parameter should be a nullptr and the
   // array will not be created.
-  prirtyLst_->CopyList(othrLst->prirtyLst_, keyedEntries_);
+  prirtyLst_.CopyList(&otherList->prirtyLst_, keyedEntries_.data());
 }
 
 unsigned long ReadyList::CmputKey_(SchedInstruction *inst, bool isUpdate,
@@ -205,23 +191,23 @@ unsigned long ReadyList::CmputKey_(SchedInstruction *inst, bool isUpdate,
 
 void ReadyList::AddLatestSubLists(LinkedList<SchedInstruction> *lst1,
                                   LinkedList<SchedInstruction> *lst2) {
-  assert(latestSubLst_->GetElmntCnt() == 0);
+  assert(latestSubLst_.GetElmntCnt() == 0);
   if (lst1 != NULL)
     AddLatestSubList_(lst1);
   if (lst2 != NULL)
     AddLatestSubList_(lst2);
-  prirtyLst_->ResetIterator();
+  prirtyLst_.ResetIterator();
 }
 
 void ReadyList::Print(std::ostream &out) {
   out << "Ready List: ";
-  for (const auto *crntInst = prirtyLst_->GetFrstElmnt(); crntInst != NULL;
-       crntInst = prirtyLst_->GetNxtElmnt()) {
+  for (const auto *crntInst = prirtyLst_.GetFrstElmnt(); crntInst != NULL;
+       crntInst = prirtyLst_.GetNxtElmnt()) {
     out << " " << crntInst->GetNum();
   }
   out << '\n';
 
-  prirtyLst_->ResetIterator();
+  prirtyLst_.ResetIterator();
 }
 
 void ReadyList::AddLatestSubList_(LinkedList<SchedInstruction> *lst) {
@@ -245,7 +231,7 @@ void ReadyList::AddLatestSubList_(LinkedList<SchedInstruction> *lst) {
     Logger::GetLogStream() << crntInst->GetNum() << ", ";
 #endif
     crntInst->PutInReadyList();
-    latestSubLst_->InsrtElmnt(crntInst);
+    latestSubLst_.InsrtElmnt(crntInst);
   }
 
 #ifdef IS_DEBUG_READY_LIST2
@@ -258,8 +244,8 @@ void ReadyList::RemoveLatestSubList() {
   Logger::GetLogStream() << "Removing from the ready list: ";
 #endif
 
-  for (SchedInstruction *inst = latestSubLst_->GetFrstElmnt(); inst != NULL;
-       inst = latestSubLst_->GetNxtElmnt()) {
+  for (SchedInstruction *inst = latestSubLst_.GetFrstElmnt(); inst != NULL;
+       inst = latestSubLst_.GetNxtElmnt()) {
     assert(inst->IsInReadyList());
     inst->RemoveFromReadyList();
 #ifdef IS_DEBUG_READY_LIST2
@@ -272,14 +258,14 @@ void ReadyList::RemoveLatestSubList() {
 #endif
 }
 
-void ReadyList::ResetIterator() { prirtyLst_->ResetIterator(); }
+void ReadyList::ResetIterator() { prirtyLst_.ResetIterator(); }
 
 void ReadyList::AddInst(SchedInstruction *inst) {
   bool changed;
   unsigned long key = CmputKey_(inst, false, changed);
   assert(changed == true);
   KeyedEntry<SchedInstruction, unsigned long> *entry =
-      prirtyLst_->InsrtElmnt(inst, key, true);
+      prirtyLst_.InsrtElmnt(inst, key, true);
   InstCount instNum = inst->GetNum();
   if (prirts_.isDynmc)
     keyedEntries_[instNum] = entry;
@@ -294,17 +280,17 @@ void ReadyList::AddList(LinkedList<SchedInstruction> *lst) {
       AddInst(crntInst);
     }
 
-  prirtyLst_->ResetIterator();
+  prirtyLst_.ResetIterator();
 }
 
-InstCount ReadyList::GetInstCnt() const { return prirtyLst_->GetElmntCnt(); }
+InstCount ReadyList::GetInstCnt() const { return prirtyLst_.GetElmntCnt(); }
 
 SchedInstruction *ReadyList::GetNextPriorityInst() {
-  return prirtyLst_->GetNxtPriorityElmnt();
+  return prirtyLst_.GetNxtPriorityElmnt();
 }
 
 SchedInstruction *ReadyList::GetNextPriorityInst(unsigned long &key) {
-  return prirtyLst_->GetNxtPriorityElmnt(key);
+  return prirtyLst_.GetNxtPriorityElmnt(key);
 }
 
 void ReadyList::UpdatePriorities() {
@@ -312,19 +298,19 @@ void ReadyList::UpdatePriorities() {
 
   SchedInstruction *inst;
   bool instChanged = false;
-  for (inst = prirtyLst_->GetFrstElmnt(); inst != NULL;
-       inst = prirtyLst_->GetNxtElmnt()) {
+  for (inst = prirtyLst_.GetFrstElmnt(); inst != NULL;
+       inst = prirtyLst_.GetNxtElmnt()) {
     unsigned long key = CmputKey_(inst, true, instChanged);
     if (instChanged) {
-      prirtyLst_->BoostEntry(keyedEntries_[inst->GetNum()], key);
+      prirtyLst_.BoostEntry(keyedEntries_[inst->GetNum()], key);
     }
   }
 }
 
-void ReadyList::RemoveNextPriorityInst() { prirtyLst_->RmvCrntElmnt(); }
+void ReadyList::RemoveNextPriorityInst() { prirtyLst_.RmvCrntElmnt(); }
 
 bool ReadyList::FindInst(SchedInstruction *inst, int &hitCnt) {
-  return prirtyLst_->FindElmnt(inst, hitCnt);
+  return prirtyLst_.FindElmnt(inst, hitCnt);
 }
 
 void ReadyList::AddPrirtyToKey_(unsigned long &key, int16_t &keySize,


### PR DESCRIPTION
Array new/delete cannot be mismatched with regular new/delete. Fix this
mismatched new/delete by replacing the pointer with llvm::SmallVector.
In the process, some member variables were embedded directly rather than
heap-allocated. This is practically free. At most, sizeof(ReadyList)
increases by the size of one pointer, which is negligible in this class.

------

This is not the cause of the undefined-behavior based mismatch of graph transformations on the GPU. However, valgrind did flag this when I was trying to debug said mismatch.