### PR TITLE
Updated hot functions list for FP benchmarks in CPU2006 with LLVM7

### DIFF
--- a/example/llvm7-CPU2006-cfg/hotfuncs.ini
+++ b/example/llvm7-CPU2006-cfg/hotfuncs.ini
@@ -1,0 +1,290 @@
+# A list of functions that we should apply optimizing scheduling to.
+# Only applies when the 'USE_OPT_SCHED' option is set to 'HOT_ONLY'.
+
+# ======================================
+# SPEC CPU2006 - FP Benchmarks
+# ======================================
+#410.bwaves
+# 77.23%
+mat_times_vec_ YES
+# 13.95%
+bi_cgstab_block_ YES
+# 4.58%
+shell_ YES
+# TOTAL: 95.76%
+
+#416.gamess
+# 23.66%
+forms_ YES
+# 18.79%
+twotff_ YES
+# 16.58%
+dirfck_ YES
+# 7.55%
+xyzint_ YES
+# 5.93%
+genral_ YES
+# 4.15%
+dirtrn_ YES
+# TOTAL: 76.66%
+
+#433.milc
+# 16.94%
+mult_su3_na YES 
+# 13.92%
+mult_su3_mat_vec YES
+# 13.56%
+mult_adj_su3_mat_vec YES
+# 12.96%
+mult_su3_nn YES
+# 7.98%
+side_link_force YES
+# 4.71%
+mult_su3_an YES
+# 4.11%
+eo_fermion_force YES
+# 4.05%
+scalar_mult_add_su3_matrix YES
+# 3.22%
+uncompress_anti_hermitian YES
+# TOTAL: 81.45%
+
+#434.zeusmp
+# 41.66%
+hsmoc_ YES
+# 21.45%
+lorentz_ YES
+# 6.09%
+momx3_ YES
+# 5.64%
+momx2_ YES
+# 4.45%
+momx1_ YES
+# 3.65%
+tranx3_ YES
+# 3.28%
+tranx2_ YES
+# TOTAL: 86.22%
+
+#435.gromacs
+# 58.19%
+inl1130_ YES
+# 18.36%
+search_neighbours YES
+# 3.12%
+put_in_list YES
+# 3.08
+inl1100_ YES
+# TOTAL: 82.75%
+
+#436.cactusADM
+# 98.20%
+bench_staggeredleapfrog2_ YES
+# TOTAL: 98.20%
+
+#437.leslie3d
+# 16.68%
+fluxj_ YES
+# 16.67%
+fluxk_ YES
+# 15.53%
+fluxi_ YES
+# 12.50%
+extrapi_ YES
+# 11.81%
+extrapj_ YES
+# 10.78%
+extrapk_ YES
+# 8.40%
+update_ YES
+# 4.56%
+setbc_ YES
+# TOTAL: 96.93
+
+#444.namd
+# 13.17%
+_ZN20ComputeNonbondedUtil26calc_pair_energy_fullelectEP9nonbonded YES
+# 12.17%
+_ZN20ComputeNonbondedUtil19calc_pair_fullelectEP9nonbonded YES
+# 10.94%
+_ZN20ComputeNonbondedUtil16calc_pair_energyEP9nonbonded YES
+# 10.92%
+_ZN20ComputeNonbondedUtil32calc_pair_energy_merge_fullelectEP9nonbonded YES
+# 10.08%
+_ZN20ComputeNonbondedUtil25calc_pair_merge_fullelectEP9nonbonded YES
+# 9.94%
+_ZN20ComputeNonbondedUtil9calc_pairEP9nonbonded YES
+# 6.72%
+_ZN20ComputeNonbondedUtil26calc_self_energy_fullelectEP9nonbonded YES
+# 5.97%
+_ZN20ComputeNonbondedUtil19calc_self_fullelectEP9nonbonded YES
+# 5.14%
+_ZN20ComputeNonbondedUtil32calc_self_energy_merge_fullelectEP9nonbonded YES
+# 5.10%
+_ZN20ComputeNonbondedUtil16calc_self_energyEP9nonbonded YES
+# 4.49%
+_ZN20ComputeNonbondedUtil25calc_self_merge_fullelectEP9nonbonded YES
+# 4.43%
+_ZN20ComputeNonbondedUtil9calc_selfEP9nonbonded YES
+# TOTAL: 99.07%
+
+#447.dealII
+# 13.53% 
+# std::_Rb_tree_increment from libstdc++
+# 10.57%
+_ZNK13LaplaceSolver6SolverILi3EE15assemble_matrixERNS1_12LinearSystemERK18TriaActiveIteratorILi3E15DoFCellAccessorILi3EEES9_RN7Threads16DummyThreadMutexE YES
+# 9.59%
+_ZNK12SparseMatrixIdE5vmultI6VectorIdES3_EEvRT_RKT0_ YES
+# 8.83%
+_ZN16ConstraintMatrix8add_lineEj YES
+# 7.59%
+_ZNK9MappingQ1ILi3EE12compute_fillERK12TriaIteratorILi3E15DoFCellAccessorILi3EEEjN10QProjectorILi3EE17DataSetDescriptorERNS0_12InternalDataERSt6vectorI5PointILi3EESaISE_EE YES
+# 5.14%
+_ZN25CompressedSparsityPattern3addEjj YES
+# 3.51%
+_ZNK15SparsityPatternclEjj YES
+# 3.33%
+_ZNK8MappingQILi3EE19transform_covariantEP6TensorILi1ELi3EES3_PKS2_RKN7MappingILi3EE16InternalDataBaseE YES
+# TOTAL: 62.09%
+
+#450.soplex
+# 19.81%
+_ZN6soplex10SPxSteepPR9entered4XENS_5SPxIdEiiiii YES
+# 16.70%
+_ZN6soplex8SSVector20assign2product4setupERKNS_5SVSetERKS0_ YES
+# 8.38%
+_ZN6soplex9CLUFactor16initFactorMatrixEPPNS_7SVectorEd YES
+# 8.35%
+_ZN6soplex9CLUFactor16vSolveUrightNoNZEPdS1_Piid YES
+# 8.04%
+_ZN6soplex8SSVector5setupEv YES
+# 4.20%
+_ZN6soplex10SPxSteepPR12selectEnterXERdiiii YES
+# 3.49%
+_ZN6soplex9SPxFastRT8maxDeltaERdS1_RNS_12UpdateVectorERNS_6VectorES5_ii YES
+# TOTAL: 68.97%
+
+#453.povray
+# 13.74%
+_ZN3povL23All_Plane_IntersectionsEPNS_13Object_StructEPNS_10Ray_StructEPNS_13istack_structE YES
+# 10.01%
+_ZN3povL31All_CSG_Intersect_IntersectionsEPNS_13Object_StructEPNS_10Ray_StructEPNS_13istack_structE YES
+# 9.62%
+_ZN3povL24All_Sphere_IntersectionsEPNS_13Object_StructEPNS_10Ray_StructEPNS_13istack_structE YES
+# 8.83%
+_ZN3pov17Check_And_EnqueueEPNS_21Priority_Queue_StructEPNS_16BBox_Tree_StructEPNS_19Bounding_Box_StructEPNS_14Rayinfo_StructE YES
+# 4.65%
+_ZN3povL12Inside_PlaneEPdPNS_13Object_StructE YES
+# 4.32%
+_ZN3pov12Ray_In_BoundEPNS_10Ray_StructEPNS_13Object_StructE YES
+# 3.85%
+_ZN3povL25All_Quadric_IntersectionsEPNS_13Object_StructEPNS_10Ray_StructEPNS_13istack_structE YES
+# 3.67%
+_ZN3pov19Intersect_BBox_TreeEPNS_16BBox_Tree_StructEPNS_10Ray_StructEPNS_10istk_entryEPPNS_13Object_StructEb YES
+# 3.54%
+_ZN3pov6DNoiseEPdS0_ YES
+# TOTAL: 62.23%
+
+#454.calculix
+# 64.71%
+e_c3d_ YES
+# 17.24%
+DVdot33 YES
+# 3.47%
+Network_findAugmentingPath YES
+# TOTAL: 85.42%
+
+#459.GemsFDTD
+# 25.70%
+nft_mod_nft_store_ YES
+# 20.76%
+upml_mod_upmlupdatee_ YES
+# 19.09%
+upml_mod_upmlupdateh_ YES
+# 14.77%
+update_mod_updatee_homo_ YES
+# 13.44%
+update_mod_updateh_homo_ YES
+# TOTAL: 93.76%
+
+#465.tonto
+# 12.54%
+shell2_module_make_ft_1_ YES
+# 11.35%
+# __mth_i_cdexp from libpgmath
+# 6.98%
+shell1quartet_module_make_esfs_ YES
+# 6.62%
+shell1quartet_module_form_esfs_no_rm_ YES
+# 5.10%
+shell1quartet_module_make_esss_ YES
+# 3.53%
+shell1quartet_module_make_ssfs_ YES
+# 3.30%
+gaussian2_module_make_ft_component_ YES
+# 3.05%
+# _int_malloc from libc-2.23
+# 2.63%
+# __alloc04_i8 from libflang
+# 2.21%
+crystal_module_sum_ft_ints_ YES
+# 1.98%
+# __fsd_sincos_avx2 from libpgmath
+# 1.95%
+# _int_free from libc-2.23
+# TOTAL: 61.24%
+
+#470.lbm
+# 98.51%
+LBM_performStreamCollide YES
+# TOTAL: 98.51%
+
+#481.wrf
+# 11.41%
+# __fss_pow_fma3 from libpgmath
+# 7.11%
+module_advect_em_advect_scalar_ YES
+# 4.61%
+sint_ YES
+# 4.11%
+module_small_step_em_advance_w_ YES
+# 3.67%
+module_mp_lin_clphy1d_ YES
+# 3.66%
+module_big_step_utilities_em_calc_cq_ YES
+# 3.63%
+module_small_step_em_advance_uv_ YES
+# 3.52%
+module_bl_ysu_ysu2d_ YES
+# 3.47%
+module_small_step_em_advance_mu_t_ YES
+# 2.76%
+# _int_free from libc-2.23
+# 2.69%
+# _int_malloc from libc-2.23
+# 2.45%
+module_mp_lin_lin_et_al_ YES
+# 2.16%
+module_small_step_em_small_step_prep_ YES
+# 1.97%
+module_small_step_em_calc_p_rho_ YES
+# 1.91%
+module_em_rk_update_scalar_ YES
+# 1.78%
+# __memset_avx2 from libc-2.23
+# TOTAL: 60.91%
+
+#482.sphinx3
+# 37.27%
+mgau_eval YES
+# 29.03%
+vector_gautbl_eval_logs3 YES
+# 7.01%
+subvq_mgau_shortlist YES
+# 6.02%
+mdef_sseq2sen_active YES
+# 4.31%
+approx_cont_mgau_frame_eval YES
+# 4.21%
+logs3_add YES
+# TOTAL: 87.85%

--- a/example/llvm7-CPU2006-cfg/machine_model.cfg
+++ b/example/llvm7-CPU2006-cfg/machine_model.cfg
@@ -1,0 +1,41 @@
+# A simple machine model which always issues one instruction in a cycle or stalls.
+MODEL_NAME: Simple
+
+# The limit on the total number of instructions that can be issued in one cycle
+ISSUE_RATE: 1
+
+# Each instruction must have an issue type, i.e. a function unit that the instruction uses.
+ISSUE_TYPE_COUNT: 1
+
+# Default issue type for LLVM instructions.
+Default 1
+
+DEP_LATENCY_ANTI: 0
+DEP_LATENCY_OUTPUT: 1
+DEP_LATENCY_OTHER: 1
+
+# This will not be used. Reg type info will be taken from the compiler.
+REG_TYPE_COUNT: 2
+I 1
+F 1
+
+# Set this to the total number of instructions
+INST_TYPE_COUNT: 0
+
+# Examples
+#1
+#INST_TYPE: ADD64rr
+#ISSUE_TYPE: Default
+#LATENCY: 1
+#PIPELINED: YES
+#BLOCKS_CYCLE: NO
+#SUPPORTED: YES
+
+
+#2
+#INST_TYPE: IMUL64rr
+#ISSUE_TYPE: Default
+#LATENCY: 3
+#PIPELINED: YES
+#BLOCKS_CYCLE: NO
+#SUPPORTED: YES

--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -1,0 +1,237 @@
+﻿# Use optimizing scheduling
+# YES
+# NO : No scheduling is done.
+# HOT_ONLY: Only use scheduler with hot functions.
+USE_OPT_SCHED YES
+
+# Print spill counts
+# Same options as use optimal scheduling.
+PRINT_SPILL_COUNTS YES
+
+# Use two pass scheduling approach.
+# First pass minimizes RP and second pass tries to balances RP and ILP.
+# YES
+# NO
+USE_TWO_PASS NO
+
+# These 3 flags control which schedulers will be used.
+# Each one can be individually toggled. The heuristic
+# list scheduler or ACO must be run before the
+# enumerator.
+# VALUES:
+# YES
+# NO
+# HEUR_ENABLED is the Heuristic scheduler.
+HEUR_ENABLED YES
+# ACO_ENABLED is the Ant Colony Optimization scheduler.
+ACO_ENABLED NO
+# ENUM_ENABLED is the Branch and Bound scheduler.
+ENUM_ENABLED YES
+
+# Controls when ACO should be run, either before or
+# after the enumerator. Both can be enabled at the
+# same time. ACO is disabled if both are disabled.
+# Run ACO before the enumerator
+# VALUES:
+# YES
+# NO
+ACO_BEFORE_ENUM YES
+# Run ACO after the enumerator
+ACO_AFTER_ENUM NO
+
+# A time limit for the whole region (basic block) in milliseconds. Defaults to no limit.
+# Interpretation depends on the TIMEOUT_PER setting.
+# Not used when the two pass scheduling approach is enabled.
+REGION_TIMEOUT 10
+
+# A time limit for each schedule length in milliseconds. Defaults to no limit.
+# Interpretation depends on the TIMEOUT_PER setting.
+# Not used when the two pass scheduling approach is enabled.
+LENGTH_TIMEOUT 10
+
+# A time limit for the whole region in milliseconds. Defaults to no limit.
+# Only used when two pass scheduling is enabled.
+# A time limit for the whole region.
+FIRST_PASS_REGION_TIMEOUT 5
+# A time limit for each schedule length.
+FIRST_PASS_LENGTH_TIMEOUT 5
+
+# A time limit for the second pass in milliseconds.
+# Only used when two pass scheduling is enabled.
+# A time limit for the whole region.
+SECOND_PASS_REGION_TIMEOUT 5
+# A time limit for each schedule length.
+SECOND_PASS_LENGTH_TIMEOUT 5
+
+# How to interpret the timeout value? Valid options:
+# INSTR : multiply the time limits in the above fields by the number of
+# instructions in the block
+# BLOCK : use the time limits in the above fields as is
+TIMEOUT_PER INSTR
+
+# The heuristic used for the list scheduler. Valid values are any combination of:
+# CP: critical path
+# LUC: last use count
+# UC: use count
+# SC: successor count
+# NID: node ID
+# LLVM: LLVM’s default list scheduler order
+# Example: LUC_CP_NID
+HEURISTIC LUC_CP_NID
+
+# The heuristic used for the enumerator. If the two pass scheduling
+# approach is enabled, then this value will be used for the first pass.
+# Same valid values as HEURISTIC.
+ENUM_HEURISTIC LUC_CP_NID
+
+# The heuuristic used for the enumerator in the second pass in the two-pass scheduling approach.
+# Same valid values as HEURISTIC.
+SECOND_PASS_ENUM_HEURISTIC LUC_CP_NID
+
+# The spill cost function to be used. Valid values are:
+# PERP: peak excess reg pressure
+# PRP: peak reg pressure
+# SUM: sum of excess reg pressures across the block
+# PEAK_PLUS_AVG: peak excess reg pressure plus the avg reg pressure across the block
+# SLIL: sum of live interval lengths for each block
+# SPILLS: number of spills after running a register allocator (doesn't work with enumerator)
+# TARGET: use target specific register pressure tracking
+SPILL_COST_FUNCTION SLIL
+
+# The weight of the spill cost in the objective function. This factor
+# defines the importance of spill cost relative to schedule length. A good
+# value for this factor should be found experimentally, but is is expected
+# to be large on architectures with hardware scheduling like x86 (thus
+# making spill cost minimization the primary objective) and smaller on
+# architectures with in-order execution like SPARC (thus making scheduling
+# the primary objective).
+SPILL_COST_WEIGHT 100
+
+# Precision of latency info:
+# PRECISE: use precise latencies from the machine_model.cfg file
+# LLVM: use latencies from LLVM
+# UNIT: use unit latencies
+LATENCY_PRECISION LLVM
+
+# The scheduler used to find an initial feasible schedule.
+# LIST: List scheduler
+# SEQ: Sequential list scheduler
+HEUR_SCHED_TYPE LIST
+
+#use 3-tournament
+ACO_TOURNAMENT YES
+
+#use fixd value for bias or not. If not, use ratio instaed
+ACO_USE_FIXED_BIAS YES
+
+#Fixed number of evaporation
+ACO_FIXED_BIAS 10
+
+# 0 to 1, ratio that will use bias
+ACO_BIAS_RATIO 0.9
+
+ACO_LOCAL_DECAY 0.1
+
+ACO_DECAY_FACTOR 0.1
+
+ACO_ANT_PER_ITERATION 10
+
+ACO_TRACE NO
+
+# The importance of the heuristic in ACO. ACO uses (1/heuristic)^importance, so
+# importance of 0 means don't use the heuristic.
+ACO_HEURISTIC_IMPORTANCE 1
+
+# ACO will stop after this many iterations with no improvement.
+ACO_STOP_ITERATIONS 50
+
+# Whether LLVM mutations should be applyed to the DAG.
+LLVM_MUTATIONS NO
+
+# (Chris) If using the SLIL cost function, enabling this option
+# will force the B&B scheduler to skip DAGs with zero PERP.
+FILTER_BY_PERP NO
+
+# If a register type has a MAX pressure below a certain threshold it is ignored.
+FILTER_REGISTERS_TYPES_WITH_LOW_PRP NO
+
+# (Chris) This setting chooses which blocks to keep and which blocks to discard.
+# The scheduler will fall back to LLVM if the block is discarded.
+# Valid options:
+#   ALL: always take the block
+#   IMPROVED: only take improved blocks
+#   OPTIMAL: only take optimal blocks
+#   IMPROVED_OR_OPTIMAL: only take improved or optimal blocks
+#   ZERO_COST: only take zero-cost blocks
+BLOCKS_TO_KEEP ALL
+
+# (Chris) Override USE_OPT_SCHED to apply to specific regions.
+# When SCHEDULE_SPECIFIC_REGIONS is set to YES, the scheduler
+# will only schedule the regions specified by
+# REGIONS_TO_SCHEDULE, which is a comma-separated list of
+# scheduling regions.
+SCHEDULE_SPECIFIC_REGIONS NO
+REGIONS_TO_SCHEDULE fft1D_512:114
+
+# Whether to use suffix concatenation. Disabled automatically if
+# history domination is disabled.
+ENABLE_SUFFIX_CONCATENATION NO
+
+# Whether to apply the node superiority graph transformation.
+STATIC_NODE_SUPERIORITY NO
+
+# Whether to apply node superiority in multiple passes.
+MULTI_PASS_NODE_SUPERIORITY NO
+
+# Whether to apply relaxed pruning. Defaults to YES.
+APPLY_RELAXED_PRUNING YES
+
+# Whether to apply spill-cost pruning. Defaults to YES.
+APPLY_SPILL_COST_PRUNING YES
+
+# Whether to apply history-based domination. Defaults to YES.
+APPLY_HISTORY_DOMINATION YES
+
+# Use simple register types. In the machine scheduler this means
+# use the first PSet associated with a RegUnit.
+USE_SIMPLE_REGISTER_TYPES NO
+
+# Should we simulate register allocation to the evaluate the effect
+# of scheduling decisions on estimated spill count.
+# BEST: Only simulate RA with the best (lowest cost) schedule.
+# LIST: Only simulate RA with the list schedule.
+# BOTH: Simulate RA using the best schedule and the list schedule.
+# TAKE_SCHED_WITH_LEAST_SPILLS: Simulate RA using the best schedule and the list schedule, and
+# take the schedule that generates the least spills.
+# NO: Do not simulate register allocation.
+SIMULATE_REGISTER_ALLOCATION BEST
+
+# Should we ignore ilp and only schedule for register pressure.
+SCHEDULE_FOR_RP_ONLY NO
+
+# Whether to enumerate schedules containing stalls (no-op instructions).
+# In certain cases, such as having unpipelined instructions, this may
+# result in a better schedule. Defaults to YES.
+ENUMERATE_STALLS YES
+
+# Whether to generate missing parts of the machine model using information from LLVM.
+# Requires a generator class for the target in machine_model.cfg.
+GENERATE_MACHINE_MODEL NO
+
+#The algorithm to use for determining the lower bound. Valid values are:
+# RJ: Rim and Jain's algorithm.
+# LC: Langevin and Cerny's algorithm.
+# Defaults to LC.
+LB_ALG LC
+
+# Whether to verify that calculated schedules are optimal. Defaults to NO.
+VERIFY_SCHEDULE YES
+
+# Whether to apply dynamic node superiority. Defaults to NO.
+DYNAMIC_NODE_SUPERIORITY NO
+
+# An option to treat data dependencies of type ORDER as data dependencies.
+TREAT_ORDER_DEPS_AS_DATA_DEPS NO
+
+# The number of bits in the hash table used in history-based domination.
+HIST_TABLE_HASH_BITS 16


### PR DESCRIPTION
This patch adds another example config directory which contains an updated hot functions list for the FP benchmarks in CPU2006 when using LLVM7. The hot functions for the INT benchmarks were removed since they are outdated.

The hot functions were gathered with `perf record` and I confirmed our scheduler was able to see the functions while scheduling.