### PR TITLE
Fix virtual function in base class's constructor not calling derived class's addLLVMMutations.

### DIFF
--- a/lib/Wrapper/AMDGPU/GCNOptSched.h
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.h
@@ -31,9 +31,6 @@ public:
   // Setup and select schedulers.
   void initSchedulers() override;
 
-  // Add the appropriate LLVM mutations. Called if LLVM_MUTATIONS is set
-  void addLLVMMutations() override;
-
   // TODO: After we refactor OptSched scheduler options put each scheduling
   // pass into its own class.
 

--- a/lib/Wrapper/OptimizingScheduler.h
+++ b/lib/Wrapper/OptimizingScheduler.h
@@ -236,9 +236,6 @@ public:
   // Setup and select schedulers for the two pass scheduling approach.
   virtual void initSchedulers();
 
-  // Add the appropriate LLVM mutations.
-  virtual void addLLVMMutations();
-
   // Execute a scheduling pass on the function.
   void runSchedPass(SchedPassStrategy S);
 


### PR DESCRIPTION
C++ does not allow calling a derived class's virtual function from the base class. Thus when using the AMDGPU target, the incorrect LLVM mutations were being applied and the AMD mutations were never added. See here: https://isocpp.org/wiki/faq/strange-inheritance#calling-virtuals-from-ctors

This patch copies how LLVM adds their mutations to be applied which is directly after creating the scheduler. See here: https://github.com/llvm/llvm-project/blob/release/6.x/llvm/lib/CodeGen/MachineScheduler.cpp#L3195

Note, the mutations won't be applied until we call postprocessDAG() which requires EnableMutations to be set to true or if called by ScheduleDAGMILive::schedule().

Tested on PlaidML (densenet121) and SHOC (FFT, GEMM, MD, Sort, Spmv, Stencil2D).