### PR TITLE
Removed whitespace causing check failure.

### DIFF
--- a/example/llvm7-CPU2006-cfg/hotfuncs.ini
+++ b/example/llvm7-CPU2006-cfg/hotfuncs.ini
@@ -30,7 +30,7 @@ dirtrn_ YES
 
 #433.milc
 # 16.94%
-mult_su3_na YES 
+mult_su3_na YES
 # 13.92%
 mult_su3_mat_vec YES
 # 13.56%
@@ -129,7 +129,7 @@ _ZN20ComputeNonbondedUtil9calc_selfEP9nonbonded YES
 # TOTAL: 99.07%
 
 #447.dealII
-# 13.53% 
+# 13.53%
 # std::_Rb_tree_increment from libstdc++
 # 10.57%
 _ZNK13LaplaceSolver6SolverILi3EE15assemble_matrixERNS1_12LinearSystemERK18TriaActiveIteratorILi3E15DoFCellAccessorILi3EEES9_RN7Threads16DummyThreadMutexE YES


### PR DESCRIPTION
The GitHub action bot missed whitespaces which caused a check failure. We should take a note for future pull requests that the bot may miss whitespace in comments or .ini files.