### PR TITLE
[AMDGPU] Removed error margin

### DIFF
--- a/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
+++ b/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
@@ -22,7 +22,7 @@ using namespace llvm::opt_sched;
 
 // This is necessary because we cannot perfectly predict the number of registers
 // of each type that will be allocated.
-static const unsigned GPRErrorMargin = 3;
+static const unsigned GPRErrorMargin = 0;
 
 #ifndef NDEBUG
 static unsigned getOccupancyWeight(unsigned Occupancy) {


### PR DESCRIPTION
The error margin used for calculating occupancy was not making a significant impact. Additionally, we perform better overall on the SHOC benchmark without using it.