### PR TITLE
Direct failed clang-format to auto-reformatter

### DIFF
--- a/.github/workflows/clangformat.yml
+++ b/.github/workflows/clangformat.yml
@@ -18,3 +18,14 @@ jobs:
       with:
         source: '.'
         clangFormatVersion: 9
+
+    - name: Report failure
+      if: ${{ failure() }}
+      run: |
+        cat << EOF
+        ::error::Something is not properly formatted by clang-format.
+
+        ::error::If you add a comment to your PR with exactly the text 'Do: Reformat' \
+        (without the quotes), each commit of your PR will be reformatted for you.
+        EOF
+        exit 1


### PR DESCRIPTION
Prints a message informing the user of the auto-reformatter for fixing the formatting of their code (a comment with: `Do: Reformat`).

I still need to verify that this works.