### PR TITLE
Fix undefined behavior with llvm_unreachable() and require valid values for some settings instead of defaults.

### DIFF
--- a/include/opt-sched/Scheduler/logger.h
+++ b/include/opt-sched/Scheduler/logger.h
@@ -48,7 +48,7 @@ void RegisterPeriodicLogger(Milliseconds period, void (*callback)());
 void PeriodicLog();
 
 // Shortcuts for each logging level.
-void Fatal(const char *format_string, ...);
+[[noreturn]] void Fatal(const char *format_string, ...);
 void Error(const char *format_string, ...);
 void Info(const char *format_string, ...);
 void Summary(const char *format_string, ...);

--- a/lib/Scheduler/logger.cpp
+++ b/lib/Scheduler/logger.cpp
@@ -97,6 +97,7 @@ void Logger::Fatal(const char *format_string, ...) {
   char message_buffer[MAX_MSGSIZE];
   VPRINT(message_buffer, format_string);
   Output(Logger::FATAL, true, message_buffer);
+  exit(1);
 }
 
 void Logger::Error(const char *format_string, ...) {

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -612,7 +612,8 @@ bool ScheduleDAGOptSched::isOptSchedEnabled() const {
     return false;
   }
 
-  Logger::Fatal("Unrecognized option for USE_OPT_SCHED setting");
+  Logger::Fatal("Unrecognized option for USE_OPT_SCHED setting: %s",
+                optSchedOption.c_str());
 }
 
 bool ScheduleDAGOptSched::isTwoPassEnabled() const {
@@ -624,7 +625,8 @@ bool ScheduleDAGOptSched::isTwoPassEnabled() const {
   else if (twoPassOption == "NO")
     return false;
 
-  Logger::Fatal("Unrecognized option for USE_TWO_PASS setting");
+  Logger::Fatal("Unrecognized option for USE_TWO_PASS setting: %s",
+                twoPassOption.c_str());
 }
 
 LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
@@ -638,7 +640,8 @@ LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
     return LTP_UNITY;
   }
 
-  Logger::Fatal("Unrecognized option for LATENCY_PRECISION setting");
+  Logger::Fatal("Unrecognized option for LATENCY_PRECISION setting: %s",
+                lpName.c_str());
 }
 
 LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
@@ -649,7 +652,7 @@ LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
     return LBA_LC;
   }
 
-  Logger::Fatal("Unrecognized option for LB_ALG setting");
+  Logger::Fatal("Unrecognized option for LB_ALG setting: %s", LBalg.c_str());
 }
 
 // Helper function to find the next substring which is a heuristic name in Str
@@ -668,7 +671,7 @@ static LISTSCHED_HEURISTIC GetNextHeuristicName(const std::string &Str,
       return LSH.HID;
     }
 
-  Logger::Fatal("Unrecognized heuristic used!");
+  Logger::Fatal("Unrecognized heuristic used: %s", Str.c_str());
 }
 
 SchedPriorities ScheduleDAGOptSched::parseHeuristic(const std::string &Str) {
@@ -715,7 +718,8 @@ SPILL_COST_FUNCTION ScheduleDAGOptSched::parseSpillCostFunc() const {
     return SCF_TARGET;
   }
 
-  Logger::Fatal("Unrecognized option for SPILL_COST_FUNCTION setting");
+  Logger::Fatal("Unrecognized option for SPILL_COST_FUNCTION setting: %s",
+                name.c_str());
 }
 
 bool ScheduleDAGOptSched::shouldPrintSpills() const {
@@ -730,7 +734,8 @@ bool ScheduleDAGOptSched::shouldPrintSpills() const {
     return HotFunctions.GetBool(functionName, false);
   }
 
-  Logger::Fatal("Unrecognized option for PRINT_SPILL_COUNTS setting");
+  Logger::Fatal("Unrecognized option for PRINT_SPILL_COUNTS setting: %s",
+                printSpills.c_str());
 }
 
 bool ScheduleDAGOptSched::rpMismatch(InstSchedule *sched) {

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -610,11 +610,9 @@ bool ScheduleDAGOptSched::isOptSchedEnabled() const {
     return HotFunctions.GetBool(functionName, false);
   } else if (optSchedOption == "NO") {
     return false;
-  } else {
-    LLVM_DEBUG(dbgs() << "Invalid value for USE_OPT_SCHED" << optSchedOption
-                      << "Assuming NO.\n");
-    return false;
   }
+
+  Logger::Fatal("Unrecognized option for USE_OPT_SCHED setting");
 }
 
 bool ScheduleDAGOptSched::isTwoPassEnabled() const {
@@ -625,7 +623,8 @@ bool ScheduleDAGOptSched::isTwoPassEnabled() const {
     return true;
   else if (twoPassOption == "NO")
     return false;
-  llvm_unreachable("Unrecognized option for USE_TWO_PASS setting.");
+
+  Logger::Fatal("Unrecognized option for USE_TWO_PASS setting");
 }
 
 LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
@@ -637,11 +636,9 @@ LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
     return LTP_ROUGH;
   } else if (lpName == "UNIT" || lpName == "UNITY") {
     return LTP_UNITY;
-  } else {
-    LLVM_DEBUG(
-        Logger::Error("Unrecognized latency precision. Defaulted to PRECISE."));
-    return LTP_PRECISE;
   }
+
+  Logger::Fatal("Unrecognized option for LATENCY_PRECISION setting");
 }
 
 LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
@@ -650,11 +647,9 @@ LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
     return LBA_RJ;
   } else if (LBalg == "LC") {
     return LBA_LC;
-  } else {
-    LLVM_DEBUG(Logger::Error(
-        "Unrecognized lower bound technique. Defaulted to Rim-Jain."));
-    return LBA_RJ;
   }
+
+  Logger::Fatal("Unrecognized option for LB_ALG setting");
 }
 
 // Helper function to find the next substring which is a heuristic name in Str
@@ -672,7 +667,8 @@ static LISTSCHED_HEURISTIC GetNextHeuristicName(const std::string &Str,
       StartIndex = Walk + 1;
       return LSH.HID;
     }
-  llvm_unreachable("Unknown heuristic.");
+
+  Logger::Fatal("Unrecognized heuristic used!");
 }
 
 SchedPriorities ScheduleDAGOptSched::parseHeuristic(const std::string &Str) {
@@ -717,11 +713,9 @@ SPILL_COST_FUNCTION ScheduleDAGOptSched::parseSpillCostFunc() const {
     return SCF_SLIL;
   } else if (name == "OCC" || name == "TARGET") {
     return SCF_TARGET;
-  } else {
-    LLVM_DEBUG(
-        Logger::Error("Unrecognized spill cost function. Defaulted to PERP."));
-    return SCF_PERP;
   }
+
+  Logger::Fatal("Unrecognized option for SPILL_COST_FUNCTION setting");
 }
 
 bool ScheduleDAGOptSched::shouldPrintSpills() const {
@@ -734,12 +728,9 @@ bool ScheduleDAGOptSched::shouldPrintSpills() const {
   } else if (printSpills == "HOT_ONLY") {
     std::string functionName = C->MF->getFunction().getName();
     return HotFunctions.GetBool(functionName, false);
-  } else {
-    LLVM_DEBUG(
-        Logger::Error("Unknown value for PRINT_SPILL_COUNTS: %s. Assuming NO.",
-                      printSpills.c_str()));
-    return false;
   }
+
+  Logger::Fatal("Unrecognized option for PRINT_SPILL_COUNTS setting");
 }
 
 bool ScheduleDAGOptSched::rpMismatch(InstSchedule *sched) {


### PR DESCRIPTION
We were using `llvm_unreachable()` incorrectly and it was causing undefined behavior. One example is when using an incorrect heuristic in combination with another heuristic such as `NOD_CP`, which should be `NID_CP`, it incorrectly gave `LLVM_CP`. This patch removes it in favor of `Logger::Fatal()` which will output an error message and cause the compiler to crash.

Some default values have also been removed and Logger::Fatal() has been put in place to ensure that a valid value is given. We do not want to automatically default to a set value and would rather instead have the program indicate that our value was incorrect.