### PR TITLE
ACO schedule constructor for schedules with stalls

### DIFF
--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -138,12 +138,12 @@ ACO_ANT_PER_ITERATION 10
 
 ACO_TRACE NO
 
-#If you want to use pheremone table debugging set ACO_DBG_REGIONS
+#If you want to use pheromone table debugging set ACO_DBG_REGIONS
 #to have a pipe '|' seperated list of scheduling regions that you want the
-#pheremone tables for. Terminate the list with a pipe symbol or the last list
+#pheromone tables for. Terminate the list with a pipe symbol or the last list
 #item will not be debugged.
 #To convert the files stored in ACO_DBG_REGIONS_OUT_PATH to a pdf see
-#util/aco_analysis/make_pheremone_pdfs.sh
+#util/aco_analysis/make_pheromone_pdfs.sh
 #Examples:
 #ACO_DBG_REGIONS kernel_c2_sdk_0:1|
 #ACO_DBG_REGIONS kernel_c2_sdk_0:1|other_region|

--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -1,4 +1,4 @@
-﻿# Use optimizing scheduling
+# Use optimizing scheduling
 # YES
 # NO : No scheduling is done.
 # HOT_ONLY: Only use scheduler with hot functions.
@@ -119,31 +119,45 @@ LATENCY_PRECISION LLVM
 HEUR_SCHED_TYPE LIST
 
 #use 3-tournament
-ACO_TOURNAMENT YES
+ACO_TOURNAMENT NO
 
 #use fixd value for bias or not. If not, use ratio instaed
 ACO_USE_FIXED_BIAS YES
 
 #Fixed number of evaporation
-ACO_FIXED_BIAS 10
+ACO_FIXED_BIAS 20
 
 # 0 to 1, ratio that will use bias
 ACO_BIAS_RATIO 0.9
 
 ACO_LOCAL_DECAY 0.1
 
-ACO_DECAY_FACTOR 0.1
+ACO_DECAY_FACTOR 0.2
 
 ACO_ANT_PER_ITERATION 10
 
 ACO_TRACE NO
+
+#If you want to use pheremone table debugging set ACO_DBG_REGIONS
+#to have a pipe '|' seperated list of scheduling regions that you want the
+#pheremone tables for. Terminate the list with a pipe symbol or the last list
+#item will not be debugged.
+#To convert the files stored in ACO_DBG_REGIONS_OUT_PATH to a pdf see
+#util/aco_analysis/make_pheremone_pdfs.sh
+#Examples:
+#ACO_DBG_REGIONS kernel_c2_sdk_0:1|
+#ACO_DBG_REGIONS kernel_c2_sdk_0:1|other_region|
+#ACO_DBG_REGIONS kernel_c2_sdk_0:1|other_region|even_more_regions|
+ACO_DBG_REGIONS NONE
+
+ACO_DBG_REGIONS_OUT_PATH /home/paul/code/CPU2006/gr_out
 
 # The importance of the heuristic in ACO. ACO uses (1/heuristic)^importance, so
 # importance of 0 means don't use the heuristic.
 ACO_HEURISTIC_IMPORTANCE 1
 
 # ACO will stop after this many iterations with no improvement.
-ACO_STOP_ITERATIONS 50
+ACO_STOP_ITERATIONS 100
 
 # Whether LLVM mutations should be applyed to the DAG.
 LLVM_MUTATIONS NO

--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -157,7 +157,7 @@ ACO_DBG_REGIONS_OUT_PATH /home/paul/code/CPU2006/gr_out
 ACO_HEURISTIC_IMPORTANCE 1
 
 # ACO will stop after this many iterations with no improvement.
-ACO_STOP_ITERATIONS 100
+ACO_STOP_ITERATIONS 50
 
 # Whether LLVM mutations should be applyed to the DAG.
 LLVM_MUTATIONS NO

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -119,20 +119,20 @@ LATENCY_PRECISION LLVM
 HEUR_SCHED_TYPE LIST
 
 #use 3-tournament
-ACO_TOURNAMENT YES
+ACO_TOURNAMENT NO
 
 #use fixd value for bias or not. If not, use ratio instaed
 ACO_USE_FIXED_BIAS YES
 
 #Fixed number of evaporation
-ACO_FIXED_BIAS 10
+ACO_FIXED_BIAS 20
 
 # 0 to 1, ratio that will use bias
 ACO_BIAS_RATIO 0.9
 
 ACO_LOCAL_DECAY 0.1
 
-ACO_DECAY_FACTOR 0.1
+ACO_DECAY_FACTOR 0.2
 
 ACO_ANT_PER_ITERATION 10
 

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -25,8 +25,8 @@ typedef double pheromone_t;
 
 struct Choice {
   SchedInstruction *inst;
-  double heuristic; // range 1 to 2
-  InstCount readyOn; //number of cycles until this instruction becomes ready
+  double heuristic;  // range 1 to 2
+  InstCount readyOn; // number of cycles until this instruction becomes ready
 };
 
 class ACOScheduler : public ConstrainedScheduler {

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -25,7 +25,8 @@ typedef double pheromone_t;
 
 struct Choice {
   SchedInstruction *inst;
-  double heuristic; // range 0 to 1
+  double heuristic; // range 1 to 2
+  InstCount readyOn; //number of cycles until this instruction becomes ready
 };
 
 class ACOScheduler : public ConstrainedScheduler {
@@ -64,8 +65,8 @@ private:
 
   // pheromone Graph Debugging end
 
-  SchedInstruction *SelectInstruction(const llvm::ArrayRef<Choice> &ready,
-                                      SchedInstruction *lastInst);
+  Choice SelectInstruction(const llvm::ArrayRef<Choice> &ready,
+                           SchedInstruction *lastInst);
   void UpdatePheromone(InstSchedule *schedule);
   std::unique_ptr<InstSchedule> FindOneSchedule();
   llvm::SmallVector<pheromone_t, 0> pheromone_;

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -82,6 +82,7 @@ private:
   bool print_aco_trace;
   std::unique_ptr<InstSchedule> InitialSchedule;
   bool VrfySched_;
+  pheromone_t ScRelMax;
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/ready_list.h
+++ b/include/opt-sched/Scheduler/ready_list.h
@@ -83,6 +83,9 @@ public:
   // Prints out the ready list, nicely formatted, into an output stream.
   void Print(std::ostream &out);
 
+  // Constructs the priority-list key based on the schemes listed in prirts_.
+  unsigned long CmputKey_(SchedInstruction *inst, bool isUpdate, bool &changed);
+
 private:
   // An ordered vector of priorities
   SchedPriorities prirts_;
@@ -117,9 +120,6 @@ private:
   int16_t ltncySumBits_;
   int16_t nodeID_Bits_;
   int16_t inptSchedOrderBits_;
-
-  // Constructs the priority-list key based on the schemes listed in prirts_.
-  unsigned long CmputKey_(SchedInstruction *inst, bool isUpdate, bool &changed);
 
   // Adds instructions at the bottom of a given list which have not been added
   // to the ready list already.

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -58,6 +58,8 @@ public:
   inline int GetCostLwrBound() { return costLwrBound_; }
   // Returns the best cost found so far for this region.
   inline InstCount GetBestCost() { return bestCost_; }
+  // Returns the heuristic cost for this region.
+  inline InstCount GetHeuristicCost() { return hurstcCost_; }
   // Returns a pointer to the list scheduler heurisitcs.
   inline SchedPriorities GetHeuristicPriorities() { return hurstcPrirts_; }
   // Get the number of simulated spills code added for this block.

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -185,6 +185,9 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
   Initialize_();
   rgn_->InitForSchdulng();
 
+  // graph debugging
+  SmallVector<InstCount, 0> chosenPath;
+
   llvm::SmallVector<Choice, 0> ready;
   while (!IsSchedComplete_()) {
     // convert the ready list from a custom priority queue to a std::vector,

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -27,6 +27,7 @@ double RandDouble(double min, double max) {
 #define MIN_DEPOSITION 1
 #define MAX_DEPOSITION 6
 #define MAX_DEPOSITION_MINUS_MIN (MAX_DEPOSITION-MIN_DEPOSITION)
+#define ACO_SCHED_STALLS 1
 
 //#define BIASED_CHOICES 10000000
 //#define LOCAL_DECAY 0.1
@@ -114,7 +115,7 @@ double ACOScheduler::Score(SchedInstruction *from, Choice choice) {
          pow(choice.heuristic, heuristicImportance_);
 }
 
-SchedInstruction *
+Choice
 ACOScheduler::SelectInstruction(const llvm::ArrayRef<Choice> &ready,
                                 SchedInstruction *lastInst) {
 #if TWO_STEP
@@ -135,7 +136,7 @@ ACOScheduler::SelectInstruction(const llvm::ArrayRef<Choice> &ready,
         maxChoice = choice;
       }
     }
-    return maxChoice.inst;
+    return maxChoice;
   }
 #endif
   if (use_tournament) {
@@ -159,12 +160,12 @@ ACOScheduler::SelectInstruction(const llvm::ArrayRef<Choice> &ready,
     }
     if (Score(lastInst, r) >=
         Score(lastInst, s)) //&& Score(lastInst, r) >= Score(lastInst, t))
-      return r.inst;
+      return r;
     //     else if (Score(lastInst, s) >= Score(lastInst, r) && Score(lastInst,
     //     s) >= Score(lastInst, t))
-    //         return s.inst;
+    //         return s;
     else
-      return s.inst;
+      return s;
   }
   pheromone_t sum = 0;
   for (auto choice : ready)
@@ -173,14 +174,15 @@ ACOScheduler::SelectInstruction(const llvm::ArrayRef<Choice> &ready,
   for (auto choice : ready) {
     point -= Score(lastInst, choice);
     if (point <= 0)
-      return choice.inst;
+      return choice;
   }
   std::cerr << "returning last instruction" << std::endl;
   assert(point < 0.001); // floats should not be this inaccurate
-  return ready.back().inst;
+  return ready.back();
 }
 
 std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
+  bool itr = false;//std::string(dataDepGraph_->GetDagID())==std::string("hmm_vit_eval_5st:6");
   SchedInstruction *lastInst = NULL;
   std::unique_ptr<InstSchedule> schedule =
       llvm::make_unique<InstSchedule>(machMdl_, dataDepGraph_, true);
@@ -190,52 +192,111 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
   Initialize_();
   rgn_->InitForSchdulng();
 
+  SchedInstruction *waitFor = NULL;
+  InstCount waitTime = 0;
   llvm::SmallVector<Choice, 0> ready;
   while (!IsSchedComplete_()) {
-    // convert the ready list from a custom priority queue to a std::vector,
-    // much nicer for this particular scheduler
     UpdtRdyLst_(crntCycleNum_, crntSlotNum_);
-    unsigned long heuristic;
-    ready.reserve(rdyLst_->GetInstCnt());
-    SchedInstruction *inst = rdyLst_->GetNextPriorityInst(heuristic);
-    while (inst != NULL) {
-      if (ChkInstLglty_(inst)) {
-        Choice c;
-        c.inst = inst;
-        c.heuristic = (double)heuristic / maxPriority + 1;
-        ready.push_back(c);
-        if (IsDbg && lastInst)
-          LastHeu[std::make_pair(lastInst->GetNum(), inst->GetNum())] =
-              c.heuristic;
+
+    //there are two steps to scheduling an instruction:
+    //1)Select the instruction(if we are not waiting on another instruction)
+    SchedInstruction *inst = NULL;
+    if (!waitFor)
+    {
+      //if we have not already committed to schedule an instruction
+      //next then pick one. First add ready instructions.  Including
+      //"illegal" e.g. blocked instructions
+
+      // convert the ready list from a custom priority queue to a std::vector,
+      // much nicer for this particular scheduler
+      ready.reserve(rdyLst_->GetInstCnt());
+      unsigned long heuristic;
+      SchedInstruction *rInst = rdyLst_->GetNextPriorityInst(heuristic);
+      while (rInst != NULL) {
+        if (ACO_SCHED_STALLS || ChkInstLglty_(rInst)) {
+          Choice c;
+          c.inst = rInst;
+          c.heuristic = (double)heuristic / maxPriority + 1;
+          c.readyOn = 0;
+          ready.push_back(c);
+          if (IsDbg && lastInst)
+            LastHeu[std::make_pair(lastInst->GetNum(), rInst->GetNum())] =
+                c.heuristic;
+        }
+        rInst = rdyLst_->GetNextPriorityInst(heuristic);
       }
-      inst = rdyLst_->GetNextPriorityInst(heuristic);
-    }
-    rdyLst_->ResetIterator();
+      rdyLst_->ResetIterator();
 
-    // print out the ready list for debugging
-    /*
-     std::stringstream stream;
-     stream << "Ready list: ";
-    for (auto choice : ready) {
-      stream << choice.inst->GetNum() << ", ";
-    }
-    Logger::Info(stream.str().c_str());
-    */
+#if ACO_SCHED_STALLS
+      //add all instructions that are waiting due to latency to the choices
+      //list
+      for(InstCount fCycle = 1; fCycle < dataDepGraph_->GetMaxLtncy() &&
+          crntCycleNum_ + fCycle < schedUprBound_; ++fCycle)
+      {
+        if(itr)
+          Logger::Info(" pre/ub:%d, ccn:%d, fc:%d",schedUprBound_,crntCycleNum_,fCycle);
+        LinkedList<SchedInstruction> *futureReady =
+          frstRdyLstPerCycle_[crntCycleNum_ + fCycle];
+        if(itr)
+          Logger::Info("post/ub:%d, ccn:%d, fc:%d",schedUprBound_,crntCycleNum_,fCycle);
+        if(!futureReady)
+          continue;
+        if(itr)
+          Logger::Info("cont/ub:%d, ccn:%d, fc:%d",schedUprBound_,crntCycleNum_,fCycle);
 
-    inst = NULL;
-    if (!ready.empty())
-      inst = SelectInstruction(ready, lastInst);
-    if (inst != NULL) {
-#if USE_ACS
-      // local pheremone decay
-      pheremone_t *pheromone = &Pheromone(lastInst, inst);
-      *pheromone = (1 - local_decay) * *pheromone + local_decay * initialValue_;
+        for(SchedInstruction *fIns = futureReady->GetFrstElmnt();fIns;
+            fIns=futureReady->GetNxtElmnt())
+        {
+          bool changed;
+          unsigned long heuristic = rdyLst_->CmputKey_(fIns, false, changed);
+          Choice c;
+          c.inst = fIns;
+          c.heuristic = (double)heuristic / maxPriority + 1;
+          c.readyOn = fCycle;
+          ready.push_back(c);
+          if (IsDbg && lastInst)
+            LastHeu[std::make_pair(lastInst->GetNum(), fIns->GetNum())] =
+                c.heuristic;
+        }
+        futureReady->ResetIterator();
+      }
 #endif
-      if (IsDbg && lastInst != NULL) {
-        AntEdges.insert(std::make_pair(lastInst->GetNum(), inst->GetNum()));
-        CrntAntEdges.insert(std::make_pair(lastInst->GetNum(), inst->GetNum()));
+
+      if (!ready.empty())
+      {
+        Choice Sel = SelectInstruction(ready, lastInst);
+        waitTime = Sel.readyOn;
+        inst = Sel.inst;
+        if(waitTime>0||!ChkInstLglty_(inst))
+        {
+          waitFor = inst;
+          inst = NULL;
+        }
       }
-      lastInst = inst;
+      if (inst != NULL) {
+#if USE_ACS
+        pheromone_t *pheromone = &Pheromone(lastInst, inst);
+        *pheromone = (1 - local_decay) * *pheromone + local_decay * initialValue_;
+#endif
+        if (IsDbg && lastInst != NULL) {
+          AntEdges.insert(std::make_pair(lastInst->GetNum(), inst->GetNum()));
+          CrntAntEdges.insert(std::make_pair(lastInst->GetNum(), inst->GetNum()));
+        }
+        lastInst = inst;
+      }
+    }
+
+    //2)Schedule a stall if we are still waiting, Schedule the instruction we are
+    //waiting for if possible, decrement waiting time
+    if(waitFor){
+      if(waitTime<=0){
+        if(ChkInstLglty_(inst)){
+          inst = waitFor;
+          waitFor = NULL;
+        }
+      }
+      else
+        waitTime--;
     }
 
     // boilerplate, mostly copied from ListScheduler, try not to touch it

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -24,8 +24,8 @@ double RandDouble(double min, double max) {
 
 #define USE_ACS 0
 #define TWO_STEP 1
-#define MIN_DEPOSITION 0
-#define MAX_DEPOSITION 3
+#define MIN_DEPOSITION 1
+#define MAX_DEPOSITION 6
 #define MAX_DEPOSITION_MINUS_MIN (MAX_DEPOSITION-MIN_DEPOSITION)
 
 //#define BIASED_CHOICES 10000000
@@ -190,9 +190,6 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
   Initialize_();
   rgn_->InitForSchdulng();
 
-  // graph debugging
-  SmallVector<InstCount, 0> chosenPath;
-
   llvm::SmallVector<Choice, 0> ready;
   while (!IsSchedComplete_()) {
     // convert the ready list from a custom priority queue to a std::vector,
@@ -205,7 +202,7 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
       if (ChkInstLglty_(inst)) {
         Choice c;
         c.inst = inst;
-        c.heuristic = (double)heuristic / maxPriority;
+        c.heuristic = (double)heuristic / maxPriority + 1;
         ready.push_back(c);
         if (IsDbg && lastInst)
           LastHeu[std::make_pair(lastInst->GetNum(), inst->GetNum())] =
@@ -229,9 +226,9 @@ std::unique_ptr<InstSchedule> ACOScheduler::FindOneSchedule() {
     if (!ready.empty())
       inst = SelectInstruction(ready, lastInst);
     if (inst != NULL) {
-#ifdef USE_ACS
-      // local pheromone decay
-      pheromone_t *pheromone = &Pheromone(lastInst, inst);
+#if USE_ACS
+      // local pheremone decay
+      pheremone_t *pheromone = &Pheromone(lastInst, inst);
       *pheromone = (1 - local_decay) * *pheromone + local_decay * initialValue_;
 #endif
       if (IsDbg && lastInst != NULL) {
@@ -277,7 +274,6 @@ FUNC_RESULT ACOScheduler::FindSchedule(InstSchedule *schedule_out,
 
   //compute the relative maximum score inverse
   ScRelMax  = rgn_->GetHeuristicCost();
-  Logger::Info("max:%d", ScRelMax);
 
   // initialize pheromone
   // for this, we need the cost of the pure heuristic schedule
@@ -394,7 +390,7 @@ void ACOScheduler::UpdatePheromone(InstSchedule *schedule) {
     for (int j = 0; j < count_; j++) {
       pheromone_t &PhPtr = Pheromone(i, j);
       PhPtr *= (1 - decay_factor);
-      PhPtr = fmax(1,fmin(10, PhPtr));
+      PhPtr = fmax(1,fmin(8, PhPtr));
     }
   }
 #endif


### PR DESCRIPTION
This PR adds the ability for the ACO Scheduler to generate schedules with stalls.  It significantly improves performance when LLVM latencies are enabled and there are instructions with a latency > 1