### PR TITLE
Convert most of our fatal error messages to use LLVM's report_fatal_error

### DIFF
--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -13,6 +13,7 @@ Last Update:  May  2020
 #include "opt-sched/Scheduler/defines.h"
 #include "opt-sched/Scheduler/logger.h"
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cstring>
 
 namespace llvm {
@@ -169,7 +170,7 @@ public:
   // element with the same key exists.
   KeyedEntry<T, K> *InsrtElmnt(T *elmnt, K key, bool allowDplct);
   // Disable the version from LinkedList.
-  void InsrtElmnt(T *) { Logger::Fatal("Unimplemented."); }
+  void InsrtElmnt(T *) { llvm::report_fatal_error("Unimplemented.", false); }
   // Updates an entry's key and moves it to its correct place.
   void BoostEntry(KeyedEntry<T, K> *entry, K newKey);
   // Gets the next element in the list, based on the "current" element.
@@ -191,7 +192,7 @@ protected:
   KeyedEntry<T, K> *AllocEntry_(T *elmnt, K key);
   // Disable the version from LinkedList.
   Entry<T> *AllocEntry_(T *) {
-    Logger::Fatal("Unimplemented.");
+    llvm::report_fatal_error("Unimplemented.", false);
     return NULL;
   }
   // Allocates all the keyed entries in a fixed-size list.
@@ -271,7 +272,7 @@ template <class T> void LinkedList<T>::RmvElmnt(const T *const elmnt) {
     }
   }
 
-  Logger::Fatal("Invalid linked list removal.");
+  llvm::report_fatal_error("Invalid linked list removal.", false);
 }
 
 template <class T> void LinkedList<T>::RmvLastElmnt() {

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -12,6 +12,7 @@
 #include "opt-sched/Scheduler/stats.h"
 #include "opt-sched/Scheduler/utilities.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <algorithm>
 #include <cstdio>
 #include <iostream>
@@ -20,6 +21,7 @@
 #include <numeric>
 #include <set>
 #include <sstream>
+#include <string>
 #include <utility>
 
 extern bool OPTSCHED_gPrintSpills;
@@ -437,8 +439,10 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
     physRegNum = use->GetPhysicalNumber();
 
     if (use->IsLive() == false)
-      Logger::Fatal("Reg %d of type %d is used without being defined", regNum,
-                    regType);
+      llvm::report_fatal_error("Reg " + std::to_string(regNum) + " of type " +
+                                   std::to_string(regType) +
+                                   " is used without being defined",
+                               false);
 
 #ifdef IS_DEBUG_REG_PRESSURE
     Logger::Info("Inst %d uses reg %d of type %d and %d uses", inst->GetNum(),

--- a/lib/Scheduler/config.cpp
+++ b/lib/Scheduler/config.cpp
@@ -1,5 +1,6 @@
 #include "opt-sched/Scheduler/config.h"
 #include "opt-sched/Scheduler/logger.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <fstream>
 #include <sstream>
 
@@ -62,7 +63,7 @@ void Config::Load(std::istream &file) {
 string Config::GetString(const string &name) const {
   std::map<string, string>::const_iterator it = settings.find(name);
   if (it == settings.end()) {
-    Logger::Fatal("No value found for setting %s.", name.c_str());
+    llvm::report_fatal_error("No value found for setting " + name, false);
     return "";
   } else {
     return it->second;

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -12,6 +12,7 @@
 #include "opt-sched/Scheduler/stats.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
 
 // only print pressure if enabled by sched.ini
 extern bool OPTSCHED_gPrintSpills;
@@ -832,7 +833,7 @@ SchedInstruction *DataDepGraph::CreateNode_(
                                     2 * instCnt_, nodeID, fileSchedOrder,
                                     fileSchedCycle, fileLB, fileUB, machMdl_);
   if (instNum < 0 || instNum >= instCnt_)
-    Logger::Fatal("Invalid instruction number");
+    llvm::report_fatal_error("Invalid instruction number", false);
   //  Logger::Info("Instruction order = %d, instCnt_ = %d", fileSchedOrder,
   //  instCnt_);
   if (fileSchedOrder > maxFileSchedOrder_)

--- a/lib/Scheduler/machine_model.cpp
+++ b/lib/Scheduler/machine_model.cpp
@@ -4,8 +4,10 @@
 // for setiosflags(), setprecision().
 #include "opt-sched/Scheduler/buffers.h"
 #include "opt-sched/Scheduler/logger.h"
+#include "llvm/Support/ErrorHandling.h"
 #include <cassert>
 #include <iomanip>
+#include <string>
 
 using namespace llvm::opt_sched;
 
@@ -28,7 +30,7 @@ MachineModel::MachineModel(const string &modelFile) {
     buf.GetNxtVldLine(pieceCnt, strngs, lngths);
 
     if (pieceCnt != 2)
-      Logger::Fatal("Invalid issue type spec");
+      llvm::report_fatal_error("Invalid issue type spec", false);
 
     issueTypes_[j].name = strngs[0];
     issueTypes_[j].slotsCount = atoi(strngs[1]);
@@ -51,7 +53,7 @@ MachineModel::MachineModel(const string &modelFile) {
     buf.GetNxtVldLine(pieceCnt, strngs, lngths);
 
     if (pieceCnt != 2) {
-      Logger::Fatal("Invalid register type spec");
+      llvm::report_fatal_error("Invalid register type spec", false);
     }
 
     registerTypes_[i].name = strngs[0];
@@ -71,8 +73,9 @@ MachineModel::MachineModel(const string &modelFile) {
     IssueType issuType = GetIssueTypeByName(buffer);
 
     if (issuType == INVALID_ISSUE_TYPE) {
-      Logger::Fatal("Invalid issue type %s for inst. type %s", buffer,
-                    it->name.c_str());
+      llvm::report_fatal_error(std::string("Invalid issue type ") + buffer +
+                                   " for inst. type " + it->name,
+                               false);
     }
 
     it->issuType = issuType;

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -2,6 +2,8 @@
 #include "opt-sched/Scheduler/register.h"
 #include "opt-sched/Scheduler/stats.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/ErrorHandling.h"
+#include <string>
 
 using namespace llvm::opt_sched;
 
@@ -257,8 +259,9 @@ bool SchedInstruction::ApplyPreFxng(LinkedList<SchedInstruction> *tightndLst,
 
 void SchedInstruction::AddDef(Register *reg) {
   if (defCnt_ >= MAX_DEFS_PER_INSTR) {
-    Logger::Fatal("An instruction can't have more than %d defs",
-                  MAX_DEFS_PER_INSTR);
+    llvm::report_fatal_error("An instruction can't have more than " +
+                                 std::to_string(MAX_DEFS_PER_INSTR) + " defs",
+                             false);
   }
   // Logger::Info("Inst %d defines reg %d of type %d and physNum %d and useCnt
   // %d",
@@ -270,8 +273,9 @@ void SchedInstruction::AddDef(Register *reg) {
 
 void SchedInstruction::AddUse(Register *reg) {
   if (useCnt_ >= MAX_USES_PER_INSTR) {
-    Logger::Fatal("An instruction can't have more than %d uses",
-                  MAX_USES_PER_INSTR);
+    llvm::report_fatal_error("An instruction can't have more than " +
+                                 std::to_string(MAX_USES_PER_INSTR) + " uses",
+                             false);
   }
   // Logger::Info("Inst %d uses reg %d of type %d and physNum %d and useCnt %d",
   // num_, reg->GetNum(), reg->GetType(), reg->GetPhysicalNumber(),

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -15,6 +15,7 @@
 #include "opt-sched/Scheduler/sched_region.h"
 #include "opt-sched/Scheduler/stats.h"
 #include "opt-sched/Scheduler/utilities.h"
+#include "llvm/Support/ErrorHandling.h"
 
 extern bool OPTSCHED_gPrintSpills;
 
@@ -134,8 +135,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
   if (!HeuristicSchedulerEnabled && !AcoBeforeEnum) {
     // Abort if ACO and heuristic algorithms are disabled.
-    Logger::Fatal(
-        "Heuristic list scheduler or ACO must be enabled before enumerator.");
+    llvm::report_fatal_error(
+        "Heuristic list scheduler or ACO must be enabled before enumerator.",
+        false);
     return RES_ERROR;
   }
 
@@ -190,7 +192,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     rslt = lstSchdulr->FindSchedule(lstSched, this);
 
     if (rslt != RES_SUCCESS) {
-      Logger::Fatal("List scheduling failed");
+      llvm::report_fatal_error("List scheduling failed", false);
       delete lstSchdulr;
       delete lstSched;
       return rslt;
@@ -269,7 +271,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
 
     rslt = runACO(AcoSchedule, lstSched);
     if (rslt != RES_SUCCESS) {
-      Logger::Fatal("ACO scheduling failed");
+      llvm::report_fatal_error("ACO scheduling failed", false);
       if (lstSchdulr)
         delete lstSchdulr;
       if (lstSched)

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
@@ -19,6 +19,7 @@
 #include "llvm/CodeGen/TargetLowering.h"
 #include "llvm/CodeGen/TargetPassConfig.h"
 #include "llvm/IR/Function.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Target/TargetMachine.h"
 #include <cstdio>
 #include <map>
@@ -98,7 +99,7 @@ void OptSchedDDGWrapperBasic::convertSUnits(bool IgnoreRealEdges,
   setupLeaf();
 
   if (Finish_() == RES_ERROR)
-    Logger::Fatal("DAG Finish_() failed.");
+    llvm::report_fatal_error("DAG Finish_() failed.", false);
 }
 
 void OptSchedDDGWrapperBasic::convertRegFiles() {

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -163,15 +163,14 @@ static BLOCKS_TO_KEEP blocksToKeep(const Config &SchedIni) {
 
 static SchedulerType parseListSchedType() {
   auto SchedTypeString =
-      SchedulerOptions::getInstance().GetString("HEUR_SCHED_TYPE", "LIST");
+      SchedulerOptions::getInstance().GetString("HEUR_SCHED_TYPE");
   if (SchedTypeString == "LIST")
     return SCHED_LIST;
   if (SchedTypeString == "SEQ")
     return SCHED_SEQ;
 
-  Logger::Info("Unknown heuristic scheduler type selected defaulting to basic "
-               "list scheduler.");
-  return SCHED_LIST;
+  llvm::report_fatal_error(
+      "Unrecognized option for HEUR_SCHED_TYPE: " + SchedTypeString, false);
 }
 
 static std::unique_ptr<GraphTrans>
@@ -612,8 +611,9 @@ bool ScheduleDAGOptSched::isOptSchedEnabled() const {
     return false;
   }
 
-  Logger::Fatal("Unrecognized option for USE_OPT_SCHED setting: %s",
-                optSchedOption.c_str());
+  llvm::report_fatal_error("Unrecognized option for USE_OPT_SCHED setting: " +
+                               optSchedOption,
+                           false);
 }
 
 bool ScheduleDAGOptSched::isTwoPassEnabled() const {
@@ -625,8 +625,8 @@ bool ScheduleDAGOptSched::isTwoPassEnabled() const {
   else if (twoPassOption == "NO")
     return false;
 
-  Logger::Fatal("Unrecognized option for USE_TWO_PASS setting: %s",
-                twoPassOption.c_str());
+  llvm::report_fatal_error(
+      "Unrecognized option for USE_TWO_PASS setting: " + twoPassOption, false);
 }
 
 LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
@@ -640,8 +640,8 @@ LATENCY_PRECISION ScheduleDAGOptSched::fetchLatencyPrecision() const {
     return LTP_UNITY;
   }
 
-  Logger::Fatal("Unrecognized option for LATENCY_PRECISION setting: %s",
-                lpName.c_str());
+  llvm::report_fatal_error(
+      "Unrecognized option for LATENCY_PRECISION setting: " + lpName, false);
 }
 
 LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
@@ -652,7 +652,8 @@ LB_ALG ScheduleDAGOptSched::parseLowerBoundAlgorithm() const {
     return LBA_LC;
   }
 
-  Logger::Fatal("Unrecognized option for LB_ALG setting: %s", LBalg.c_str());
+  llvm::report_fatal_error("Unrecognized option for LB_ALG setting: " + LBalg,
+                           false);
 }
 
 // Helper function to find the next substring which is a heuristic name in Str
@@ -671,7 +672,7 @@ static LISTSCHED_HEURISTIC GetNextHeuristicName(const std::string &Str,
       return LSH.HID;
     }
 
-  Logger::Fatal("Unrecognized heuristic used: %s", Str.c_str());
+  llvm::report_fatal_error("Unrecognized heuristic used: " + Str, false);
 }
 
 SchedPriorities ScheduleDAGOptSched::parseHeuristic(const std::string &Str) {
@@ -718,8 +719,8 @@ SPILL_COST_FUNCTION ScheduleDAGOptSched::parseSpillCostFunc() const {
     return SCF_TARGET;
   }
 
-  Logger::Fatal("Unrecognized option for SPILL_COST_FUNCTION setting: %s",
-                name.c_str());
+  llvm::report_fatal_error(
+      "Unrecognized option for SPILL_COST_FUNCTION setting: " + name, false);
 }
 
 bool ScheduleDAGOptSched::shouldPrintSpills() const {
@@ -734,8 +735,9 @@ bool ScheduleDAGOptSched::shouldPrintSpills() const {
     return HotFunctions.GetBool(functionName, false);
   }
 
-  Logger::Fatal("Unrecognized option for PRINT_SPILL_COUNTS setting: %s",
-                printSpills.c_str());
+  llvm::report_fatal_error(
+      "Unrecognized option for PRINT_SPILL_COUNTS setting: " + printSpills,
+      false);
 }
 
 bool ScheduleDAGOptSched::rpMismatch(InstSchedule *sched) {


### PR DESCRIPTION
This patch converts most of our fatal error messages to use `llvm:report_fatal_error` instead of `Logger::Fatal`. Both essentially perform the same functionality but we want to move closer to LLVM style.