### PR TITLE
Output unit test information

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -52,7 +52,7 @@ jobs:
           CCACHE_COMPRESSLEVEL: 6
 
       - name: unit tests
-        run: ninja test
+        run: ctest -VV
         working-directory: ./build
 
       - name: dump ccache statistics


### PR DESCRIPTION
Previously, the GitHub workflow did not output any useful information about the unit tests other than whether or not they failed. When they do fail, it is important to see why. This PR makes the workflow show the output of the test.