### PR TITLE
Retry the build a number of times before failing

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -43,7 +43,11 @@ jobs:
       - name: build
         run: |
           ccache -z
-          ninja
+          ninja || true
+          (ninja | grep -E -v '^-- Up-to-date: ') || true
+          (ninja | grep -E -v '^-- Up-to-date: ') || true
+          (ninja | grep -E -v '^-- Up-to-date: ') || true
+          (ninja | grep -E -v '^-- Up-to-date: ')
         working-directory: ./build
         env:
           CCACHE_BASEDIR: $GITHUB_WORKSPACE


### PR DESCRIPTION
LLVM has some dependencies between targets which are not properly set up
in CMake. The simplest workaround is to rerun the build a few times.