### PR TITLE
Removal of weighted-cost for two pass

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -12,7 +12,7 @@ PRINT_SPILL_COUNTS YES
 # First pass minimizes RP and second pass tries to balances RP and ILP.
 # YES
 # NO
-USE_TWO_PASS YES
+USE_TWO_PASS NO
 
 # These 3 flags control which schedulers will be used.
 # Each one can be individually toggled. The heuristic

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -12,7 +12,7 @@ PRINT_SPILL_COUNTS YES
 # First pass minimizes RP and second pass tries to balances RP and ILP.
 # YES
 # NO
-USE_TWO_PASS NO
+USE_TWO_PASS YES
 
 # These 3 flags control which schedulers will be used.
 # Each one can be individually toggled. The heuristic

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -65,6 +65,9 @@ public:
   // Get the number of simulated spills code added for this block.
   inline int GetSimSpills() { return totalSimSpills_; }
 
+  // Get schedLength for best-so-far sched
+  inline InstCount GetBestSchedLength() { return bestSchedLngth_; }
+
   // TODO(max): Document.
   virtual FUNC_RESULT
   FindOptimalSchedule(Milliseconds rgnTimeout, Milliseconds lngthTimeout,
@@ -109,6 +112,9 @@ public:
   // Initialize variables for the second pass of the two-pass-optsched
   void InitSecondPass();
 
+  // Initiliaze variables to reflect that we are using two-pass version of algorithm
+  void InitTwoPassAlg();
+
 private:
   // The algorithm to use for calculated lower bounds.
   LB_ALG lbAlg_;
@@ -119,6 +125,10 @@ private:
 
   // The normal heuristic scheduling results.
   InstCount hurstcCost_;
+    
+  // Spill cost for heuristic schedule
+  InstCount hurstcSpillCost_;
+
 
   // total simulated spills.
   int totalSimSpills_;
@@ -150,6 +160,9 @@ private:
   // The pruning technique to use for this region.
   Pruning prune_;
 
+  // Whether or not we are using two-pass version of algorithm
+  bool twoPassEnabled_;
+
 protected:
   // The dependence graph of this region.
   DataDepGraph *dataDepGraph_;
@@ -179,6 +192,10 @@ protected:
   SchedulerType GetHeuristicSchedulerType() const { return HeurSchedType_; }
 
   bool IsSecondPass() const { return isSecondPass_; }
+
+  bool IsTwoPassEnabled() const { return twoPassEnabled_; }
+
+  InstCount GetFirstPassSpillCost() const { return hurstcSpillCost_; }
 
   void SetBestCost(InstCount bestCost) { bestCost_ = bestCost; }
 

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -66,7 +66,7 @@ public:
   inline int GetSimSpills() { return totalSimSpills_; }
 
   // Get schedLength for best-so-far sched
-  inline InstCount GetBestSchedLength() { return bestSchedLngth_; }
+  inline InstCount getBestSchedLength() { return bestSchedLngth_; }
 
   // TODO(max): Document.
   virtual FUNC_RESULT
@@ -113,7 +113,7 @@ public:
   void InitSecondPass();
 
   // Initiliaze variables to reflect that we are using two-pass version of algorithm
-  void InitTwoPassAlg();
+  void initTwoPassAlg();
 
 private:
   // The algorithm to use for calculated lower bounds.
@@ -127,8 +127,7 @@ private:
   InstCount hurstcCost_;
     
   // Spill cost for heuristic schedule
-  InstCount hurstcSpillCost_;
-
+  InstCount HurstcSpillCost_;
 
   // total simulated spills.
   int totalSimSpills_;
@@ -161,7 +160,7 @@ private:
   Pruning prune_;
 
   // Whether or not we are using two-pass version of algorithm
-  bool twoPassEnabled_;
+  bool TwoPassEnabled_;
 
 protected:
   // The dependence graph of this region.
@@ -193,9 +192,9 @@ protected:
 
   bool IsSecondPass() const { return isSecondPass_; }
 
-  bool IsTwoPassEnabled() const { return twoPassEnabled_; }
+  bool isTwoPassEnabled() const { return TwoPassEnabled_; }
 
-  InstCount GetFirstPassSpillCost() const { return hurstcSpillCost_; }
+  InstCount getFirstPassSpillCost() const { return HurstcSpillCost_; }
 
   void SetBestCost(InstCount bestCost) { bestCost_ = bestCost; }
 

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -870,11 +870,12 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
   //    only schedules meeting trgt length will make it this far,
   //    thus we don't need to check that condition
   // non two-pass & found better weighted cost 
-  if (
+  /*if (
       (IsSecondPass() && crntSpillCost_ <= GetFirstPassSpillCost() && 
         crntSched->GetCrntLngth() < GetBestSchedLength()) 
       || (!IsSecondPass() && IsTwoPassEnabled() && crntSpillCost_ < optmlSpillCost_) 
-      || (!IsTwoPassEnabled() && crntCost < GetBestCost()))    
+      || (!IsTwoPassEnabled() && crntCost < GetBestCost()))    */
+  if (crntCost < GetBestCost())
   {
     if (!IsTwoPassEnabled() && crntSched->GetCrntLngth() > schedLwrBound_)
       Logger::Info("$$$ GOOD_HIT: Better spill cost for a longer schedule");
@@ -919,18 +920,18 @@ bool BBWithSpill::ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *node) {
     
     //If second pass -- check that our RP is held at first pass RP
     //If first pass -- minimize RP
-    if (IsSecondPass())
-      fsbl = (dynamicSlilLowerBound_ <= GetFirstPassSpillCost());
-    else if (IsTwoPassEnabled() && !IsSecondPass())
-      fsbl = dynamicSlilLowerBound_ <= optmlSpillCost_;
+    //if (IsSecondPass())
+    //  fsbl = (dynamicSlilLowerBound_ <= GetFirstPassSpillCost());
+    //else if (IsTwoPassEnabled() && !IsSecondPass())
+    //  fsbl = dynamicSlilLowerBound_ <= optmlSpillCost_;
 
   } else {
     crntCost = crntSpillCost_ * SCW_ + trgtLngth * schedCostFactor_;
     
-    if (IsSecondPass())
-      fsbl = (crntSpillCost_ <= GetFirstPassSpillCost());
-    else if (IsTwoPassEnabled() && !IsSecondPass())
-      fsbl = crntSpillCost_ <= optmlSpillCost_;
+    //if (IsSecondPass())
+    //  fsbl = (crntSpillCost_ <= GetFirstPassSpillCost());
+    //else if (IsTwoPassEnabled() && !IsSecondPass())
+    //  fsbl = crntSpillCost_ <= optmlSpillCost_;
   }
 
   crntCost -= GetCostLwrBound();
@@ -938,7 +939,7 @@ bool BBWithSpill::ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *node) {
   // assert(cost >= 0);
   assert(crntCost >= 0);
 
-  if (!IsTwoPassEnabled())
+  //if (!IsTwoPassEnabled())
     fsbl = crntCost < GetBestCost();
 
   // FIXME: RP tracking should be limited to the current SCF. We need RP

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -870,14 +870,14 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
   //    only schedules meeting trgt length will make it this far,
   //    thus we don't need to check that condition
   // non two-pass & found better weighted cost 
-  /*if (
-      (IsSecondPass() && crntSpillCost_ <= GetFirstPassSpillCost() && 
-        crntSched->GetCrntLngth() < GetBestSchedLength()) 
-      || (!IsSecondPass() && IsTwoPassEnabled() && crntSpillCost_ < optmlSpillCost_) 
-      || (!IsTwoPassEnabled() && crntCost < GetBestCost()))    */
-  if (crntCost < GetBestCost())
+  if (
+      (IsSecondPass() && crntSpillCost_ <= getFirstPassSpillCost() && 
+        crntSched->GetCrntLngth() < getBestSchedLength()) 
+      || (!IsSecondPass() && isTwoPassEnabled() && crntSpillCost_ < optmlSpillCost_) 
+      || (!isTwoPassEnabled() && crntCost < GetBestCost()))    
+  //if (crntCost < GetBestCost())
   {
-    if (!IsTwoPassEnabled() && crntSched->GetCrntLngth() > schedLwrBound_)
+    if (!isTwoPassEnabled() && crntSched->GetCrntLngth() > schedLwrBound_)
       Logger::Info("$$$ GOOD_HIT: Better spill cost for a longer schedule");
 
     SetBestCost(crntCost);
@@ -920,18 +920,18 @@ bool BBWithSpill::ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *node) {
     
     //If second pass -- check that our RP is held at first pass RP
     //If first pass -- minimize RP
-    //if (IsSecondPass())
-    //  fsbl = (dynamicSlilLowerBound_ <= GetFirstPassSpillCost());
-    //else if (IsTwoPassEnabled() && !IsSecondPass())
-    //  fsbl = dynamicSlilLowerBound_ <= optmlSpillCost_;
+    if (IsSecondPass())
+      fsbl = (dynamicSlilLowerBound_ <= getFirstPassSpillCost());
+    else if (isTwoPassEnabled() && !IsSecondPass())
+      fsbl = dynamicSlilLowerBound_ <= optmlSpillCost_;
 
   } else {
     crntCost = crntSpillCost_ * SCW_ + trgtLngth * schedCostFactor_;
     
-    //if (IsSecondPass())
-    //  fsbl = (crntSpillCost_ <= GetFirstPassSpillCost());
-    //else if (IsTwoPassEnabled() && !IsSecondPass())
-    //  fsbl = crntSpillCost_ <= optmlSpillCost_;
+    if (IsSecondPass())
+      fsbl = (crntSpillCost_ <= getFirstPassSpillCost());
+    else if (isTwoPassEnabled() && !IsSecondPass())
+      fsbl = crntSpillCost_ <= optmlSpillCost_;
   }
 
   crntCost -= GetCostLwrBound();
@@ -939,7 +939,7 @@ bool BBWithSpill::ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *node) {
   // assert(cost >= 0);
   assert(crntCost >= 0);
 
-  //if (!IsTwoPassEnabled())
+  if (!isTwoPassEnabled())
     fsbl = crntCost < GetBestCost();
 
   // FIXME: RP tracking should be limited to the current SCF. We need RP

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -875,7 +875,6 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
         crntSched->GetCrntLngth() < getBestSchedLength()) 
       || (!IsSecondPass() && isTwoPassEnabled() && crntSpillCost_ < optmlSpillCost_) 
       || (!isTwoPassEnabled() && crntCost < GetBestCost()))    
-  //if (crntCost < GetBestCost())
   {
     if (!isTwoPassEnabled() && crntSched->GetCrntLngth() > schedLwrBound_)
       Logger::Info("$$$ GOOD_HIT: Better spill cost for a longer schedule");

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -234,7 +234,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     hurstcCost_ = lstSched->GetCost();
 
     // Get unweighted spill cost for Heurstic list scheduler
-    hurstcSpillCost_ = lstSched->GetSpillCost();
+    HurstcSpillCost_ = lstSched->GetSpillCost();
 
     // This schedule is optimal so ACO will not be run
     // so set bestSched here.
@@ -832,7 +832,7 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
 
 void SchedRegion::InitSecondPass() { isSecondPass_ = true; }
 
-void SchedRegion::InitTwoPassAlg() { twoPassEnabled_ = true; }
+void SchedRegion::initTwoPassAlg() { TwoPassEnabled_ = true; }
 
 FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
                                 InstSchedule *InitSched) {

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -233,6 +233,9 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     CmputNormCost_(lstSched, CCM_DYNMC, hurstcExecCost, true);
     hurstcCost_ = lstSched->GetCost();
 
+    // Get unweighted spill cost for Heurstic list scheduler
+    hurstcSpillCost_ = lstSched->GetSpillCost();
+
     // This schedule is optimal so ACO will not be run
     // so set bestSched here.
     if (hurstcCost_ == 0) {
@@ -828,6 +831,8 @@ void SchedRegion::RegAlloc_(InstSchedule *&bestSched, InstSchedule *&lstSched) {
 }
 
 void SchedRegion::InitSecondPass() { isSecondPass_ = true; }
+
+void SchedRegion::InitTwoPassAlg() { twoPassEnabled_ = true; }
 
 FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
                                 InstSchedule *InitSched) {


### PR DESCRIPTION
Added control flow logic in UpdateOptimalSchedule and CheckCostFeasibility such that if we are in the first or second pass of two pass algorithm, we check raw values spillCost and/or schedule length. This results in removal of weighted sum for two-pass algorithm.

Additionally, there was some minor code bloat in CheckCostFeasbility, and, since this is relatively hot code, I fixed for it.