### PR TITLE
Fixed runspec-wrapper bug where timedout block improvements were not counted

### DIFF
--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -533,7 +533,12 @@ def calculateBlockStats(output, trackOptSchedSpills):
                     The rest of this if-block ensures that this tool doesn't crash.
                     If the improvement is not found, it is assumed to be 0.
                     """
-                    improvement = events['DagSolvedOptimally']['cost_improvement'] if isOptimal else 0
+                    if isOptimal:
+                        improvement = events['DagSolvedOptimally']['cost_improvement']
+                    elif 'DagTimedOut' in events:
+                        improvement = events['DagTimedOut']['cost_improvement']
+                    else:
+                        improvement = 0
                 else:
                     isOptimal = False
                     improvement = 0


### PR DESCRIPTION

NOTE: ANY B&B COMPILE TIME COSTS THAT WERE GENERATED WITH THE JSON RUNSPEC WRAPPER ARE TAINTED AND SHOULD NOT BE USED