### PR TITLE
Add a JSON -> info log conversion script

### DIFF
--- a/util/misc/json2infolog.py
+++ b/util/misc/json2infolog.py
@@ -25,41 +25,38 @@ def translate_args(cont, **kwargs):
 def format(s, cont=identity):
     return lambda log: cont(s.format(**log))
 
-def produce(s, cont=identity):
-    return lambda _: cont(s)
-
-discard = produce(None)
+discard = lambda _: None
 
 TR_TABLE = {
-    'StaticLowerBoundDebugInfo': format('INFO: DAG {name} spillCostLB {spill_cost_lb} scFactor {sc_factor} lengthLB {length_lb} lenFactor {len_factor} staticLB {static_lb}'),
-    'Enumerating': format('INFO: Enumerating at target length {target_length}'),
-    'ScheduleVerifiedSuccessfully': discard, # produce('INFO: Schedule verified successfully'),
-    'ProcessDag': discard, # format('INFO: Processing DAG {name} with {num_instructions} insts and max latency {max_latency}.'),
-    'HeuristicResult': discard, # format('INFO: The list schedule is of length {length} and spill cost {spill_cost}. Tot cost = {cost}'),
-    'CostLowerBound': discard, # format('INFO: Lower bound of cost before scheduling: {cost}'),
-    'BypassZeroTimeLimit': discard, # format('INFO: Bypassing optimal scheduling due to zero time limit with cost {cost}'),
-    'HeuristicScheduleOptimal': format('INFO: The initial schedule of length {length} and cost {cost} is optimal.'),
+    'StaticLowerBoundDebugInfo': format('INFO: DAG {name} spillCostLB {spill_cost_lb} scFactor {sc_factor} lengthLB {length_lb} lenFactor {len_factor} staticLB {static_lb} (Time = {time} ms)'),
+    'Enumerating': format('INFO: Enumerating at target length {target_length} (Time = {time} ms)'),
+    'ScheduleVerifiedSuccessfully': discard, # format('INFO: Schedule verified successfully (Time = {time} ms)'),
+    'ProcessDag': discard, # format('INFO: Processing DAG {name} with {num_instructions} insts and max latency {max_latency}. (Time = {time} ms)'),
+    'HeuristicResult': discard, # format('INFO: The list schedule is of length {length} and spill cost {spill_cost}. Tot cost = {cost} (Time = {time} ms)'),
+    'CostLowerBound': discard, # format('INFO: Lower bound of cost before scheduling: {cost} (Time = {time} ms)'),
+    'BypassZeroTimeLimit': discard, # format('INFO: Bypassing optimal scheduling due to zero time limit with cost {cost} (Time = {time} ms)'),
+    'HeuristicScheduleOptimal': format('INFO: The initial schedule of length {length} and cost {cost} is optimal. (Time = {time} ms)'),
     'BestResult': discard,
         # translate_args(
-        #     format('INFO: Best schedule for DAG {name} has cost {cost} and length {length}. The schedule is {optimal}'),
+        #     format('INFO: Best schedule for DAG {name} has cost {cost} and length {length}. The schedule is {optimal} (Time = {time} ms)'),
         #     optimal=lambda opt: 'optimal' if opt else 'not optimal'
         # ),
-    'SlilStats': discard, # format('INFO: SLIL stats: DAG {name} static LB {static_lb} gap size {gap_size} enumerated {is_enumerated} optimal {is_optimal} PERP higher {is_perp_higher}'),
-    'NodeExamineCount': format('INFO: Examined {num_nodes} nodes.'),
-    'DagSolvedOptimally': discard, # format('INFO: DAG solved optimally in {solution_time} ms with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
-    'DagTimedOut': format('INFO: DAG timed out with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
+    'SlilStats': discard, # format('INFO: SLIL stats: DAG {name} static LB {static_lb} gap size {gap_size} enumerated {is_enumerated} optimal {is_optimal} PERP higher {is_perp_higher} (Time = {time} ms)'),
+    'NodeExamineCount': format('INFO: Examined {num_nodes} nodes. (Time = {time} ms)'),
+    'DagSolvedOptimally': discard, # format('INFO: DAG solved optimally in {solution_time} ms with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}. (Time = {time} ms)'),
+    'DagTimedOut': format('INFO: DAG timed out with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}. (Time = {time} ms)'),
     'HeuristicLocalRegAllocSimulation': format(
         dedent('''\
-        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} ***heuristic_schedule*** Number of spills: {num_spills}
-        INFO: Number of stores {num_stores}
-        INFO: Number of loads {num_loads}''')),
+        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} ***heuristic_schedule*** Number of spills: {num_spills} (Time = {time} ms)
+        INFO: Number of stores {num_stores} (Time = {time} ms)
+        INFO: Number of loads {num_loads} (Time = {time} ms)''')),
     'BestLocalRegAllocSimulation': format(
         dedent('''\
-        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} Number of spills: {num_spills}
-        INFO: Number of stores {num_stores}
-        INFO: Number of loads {num_loads}''')),
+        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} Number of spills: {num_spills} (Time = {time} ms)
+        INFO: Number of stores {num_stores} (Time = {time} ms)
+        INFO: Number of loads {num_loads} (Time = {time} ms)''')),
     'LocalRegAllocSimulationChoice': discard,
-    'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n', 'INFO: End of second pass through')[log['num']],
+    'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n (Time = {time} ms)', 'INFO: End of second pass through (Time = {time} ms)')[log['num']].format(time=log['time']),
 }
 
 

--- a/util/misc/json2infolog.py
+++ b/util/misc/json2infolog.py
@@ -56,7 +56,7 @@ TR_TABLE = {
         INFO: Number of stores {num_stores} (Time = {time} ms)
         INFO: Number of loads {num_loads} (Time = {time} ms)''')),
     'LocalRegAllocSimulationChoice': discard,
-    'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n (Time = {time} ms)', 'INFO: End of second pass through (Time = {time} ms)')[log['num']].format(time=log['time']),
+    'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n (Time = {time} ms)', 'INFO: End of second pass through (Time = {time} ms)')[log['num'] - 1].format(time=log['time']),
 }
 
 

--- a/util/misc/json2infolog.py
+++ b/util/misc/json2infolog.py
@@ -101,6 +101,9 @@ TR_TABLE = {
         INFO: Number of loads {num_loads} (Time = {time} ms)''')),
     'LocalRegAllocSimulationChoice': discard,
     'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n (Time = {time} ms)', 'INFO: End of second pass through (Time = {time} ms)')[log['num'] - 1].format(time=log['time']),
+
+    'AcoPostSchedComplete': pass_through,
+    'ACOSchedComplete': pass_through,
 }
 
 

--- a/util/misc/json2infolog.py
+++ b/util/misc/json2infolog.py
@@ -31,35 +31,35 @@ def produce(s, cont=identity):
 discard = produce(None)
 
 TR_TABLE = {
-    'StaticLowerBoundDebugInfo': format('DAG {name} spillCostLB {spill_cost_lb} scFactor {sc_factor} lengthLB {length_lb} lenFactor {len_factor} staticLB {static_lb}'),
-    'Enumerating': format('Enumerating at target length {target_length}'),
-    'ScheduleVerifiedSuccessfully': discard, # produce('Schedule verified successfully'),
-    'ProcessDag': discard, # format('Processing DAG {name} with {num_instructions} insts and max latency {max_latency}.'),
-    'HeuristicResult': discard, # format('The list schedule is of length {length} and spill cost {spill_cost}. Tot cost = {cost}'),
-    'CostLowerBound': discard, # format('Lower bound of cost before scheduling: {cost}'),
-    'BypassZeroTimeLimit': discard, # format('Bypassing optimal scheduling due to zero time limit with cost {cost}'),
-    'HeuristicScheduleOptimal': format('The initial schedule of length {length} and cost {cost} is optimal.'),
+    'StaticLowerBoundDebugInfo': format('INFO: DAG {name} spillCostLB {spill_cost_lb} scFactor {sc_factor} lengthLB {length_lb} lenFactor {len_factor} staticLB {static_lb}'),
+    'Enumerating': format('INFO: Enumerating at target length {target_length}'),
+    'ScheduleVerifiedSuccessfully': discard, # produce('INFO: Schedule verified successfully'),
+    'ProcessDag': discard, # format('INFO: Processing DAG {name} with {num_instructions} insts and max latency {max_latency}.'),
+    'HeuristicResult': discard, # format('INFO: The list schedule is of length {length} and spill cost {spill_cost}. Tot cost = {cost}'),
+    'CostLowerBound': discard, # format('INFO: Lower bound of cost before scheduling: {cost}'),
+    'BypassZeroTimeLimit': discard, # format('INFO: Bypassing optimal scheduling due to zero time limit with cost {cost}'),
+    'HeuristicScheduleOptimal': format('INFO: The initial schedule of length {length} and cost {cost} is optimal.'),
     'BestResult': discard,
         # translate_args(
-        #     format('Best schedule for DAG {name} has cost {cost} and length {length}. The schedule is {optimal}'),
+        #     format('INFO: Best schedule for DAG {name} has cost {cost} and length {length}. The schedule is {optimal}'),
         #     optimal=lambda opt: 'optimal' if opt else 'not optimal'
         # ),
-    'SlilStats': discard, # format('SLIL stats: DAG {name} static LB {static_lb} gap size {gap_size} enumerated {is_enumerated} optimal {is_optimal} PERP higher {is_perp_higher}'),
-    'NodeExamineCount': format('Examined {num_nodes} nodes.'),
-    'DagSolvedOptimally': discard, # format('DAG solved optimally in {solution_time} ms with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
-    'DagTimedOut': format('DAG timed out with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
+    'SlilStats': discard, # format('INFO: SLIL stats: DAG {name} static LB {static_lb} gap size {gap_size} enumerated {is_enumerated} optimal {is_optimal} PERP higher {is_perp_higher}'),
+    'NodeExamineCount': format('INFO: Examined {num_nodes} nodes.'),
+    'DagSolvedOptimally': discard, # format('INFO: DAG solved optimally in {solution_time} ms with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
+    'DagTimedOut': format('INFO: DAG timed out with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
     'HeuristicLocalRegAllocSimulation': format(
         dedent('''\
-        OPT_SCHED LOCAL RA: DAG Name: {dag_name} ***heuristic_schedule*** Number of spills: {num_spills}
-        Number of stores {num_stores}
-        Number of loads {num_loads}''')),
+        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} ***heuristic_schedule*** Number of spills: {num_spills}
+        INFO: Number of stores {num_stores}
+        INFO: Number of loads {num_loads}''')),
     'BestLocalRegAllocSimulation': format(
         dedent('''\
-        OPT_SCHED LOCAL RA: DAG Name: {dag_name} Number of spills: {num_spills}
-        Number of stores {num_stores}
-        Number of loads {num_loads}''')),
+        INFO: OPT_SCHED LOCAL RA: DAG Name: {dag_name} Number of spills: {num_spills}
+        INFO: Number of stores {num_stores}
+        INFO: Number of loads {num_loads}''')),
     'LocalRegAllocSimulationChoice': discard,
-    'PassFinished': discard, # lambda log: ('End of first pass through\n', 'End of second pass through')[log['num']],
+    'PassFinished': discard, # lambda log: ('INFO: End of first pass through\n', 'INFO: End of second pass through')[log['num']],
 }
 
 
@@ -72,7 +72,9 @@ def translate(infile, outfile):
 
         parsed = json.loads(line.split(' ', 1)[1])
         tr = TR_TABLE[parsed['event_id']]
-        print(tr(parsed), file=outfile)
+        result = tr(parsed)
+        if result is not None:
+            print(result, file=outfile)
 
 
 for inpath, outpath in zip(args.input, args.output):

--- a/util/misc/json2infolog.py
+++ b/util/misc/json2infolog.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+import json
+from textwrap import dedent
+
+parser = argparse.ArgumentParser(description='Convert data_dep WriteToFile format to a .dot file')
+parser.add_argument('-i', '--input', required=True, nargs='+', help='The WriteToFile format file to convert.')
+parser.add_argument('-o', '--output', required=True, nargs='+', help='The destination to write to.')
+
+args = parser.parse_args()
+if len(args.input) != len(args.output):
+    parser.error(f'Differing number of inputs and outputs: {args.input} vs {args.output}')
+
+identity = lambda x: x
+
+def translate_args(cont, **kwargs):
+    def translate(log):
+        for name, f in kwargs.items():
+            log[name] = f(log[name])
+
+        return cont(log)
+    return translate
+
+def format(s, cont=identity):
+    return lambda log: cont(s.format(**log))
+
+def produce(s, cont=identity):
+    return lambda _: cont(s)
+
+discard = produce(None)
+
+TR_TABLE = {
+    'StaticLowerBoundDebugInfo': format('DAG {name} spillCostLB {spill_cost_lb} scFactor {sc_factor} lengthLB {length_lb} lenFactor {len_factor} staticLB {static_lb}'),
+    'Enumerating': format('Enumerating at target length {target_length}'),
+    'ScheduleVerifiedSuccessfully': discard, # produce('Schedule verified successfully'),
+    'ProcessDag': discard, # format('Processing DAG {name} with {num_instructions} insts and max latency {max_latency}.'),
+    'HeuristicResult': discard, # format('The list schedule is of length {length} and spill cost {spill_cost}. Tot cost = {cost}'),
+    'CostLowerBound': discard, # format('Lower bound of cost before scheduling: {cost}'),
+    'BypassZeroTimeLimit': discard, # format('Bypassing optimal scheduling due to zero time limit with cost {cost}'),
+    'HeuristicScheduleOptimal': format('The initial schedule of length {length} and cost {cost} is optimal.'),
+    'BestResult': discard,
+        # translate_args(
+        #     format('Best schedule for DAG {name} has cost {cost} and length {length}. The schedule is {optimal}'),
+        #     optimal=lambda opt: 'optimal' if opt else 'not optimal'
+        # ),
+    'SlilStats': discard, # format('SLIL stats: DAG {name} static LB {static_lb} gap size {gap_size} enumerated {is_enumerated} optimal {is_optimal} PERP higher {is_perp_higher}'),
+    'NodeExamineCount': format('Examined {num_nodes} nodes.'),
+    'DagSolvedOptimally': discard, # format('DAG solved optimally in {solution_time} ms with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
+    'DagTimedOut': format('DAG timed out with length={length}, spill cost = {spill_cost}, tot cost = {total_cost}, cost imp={cost_improvement}.'),
+    'HeuristicLocalRegAllocSimulation': format(
+        dedent('''\
+        OPT_SCHED LOCAL RA: DAG Name: {dag_name} ***heuristic_schedule*** Number of spills: {num_spills}
+        Number of stores {num_stores}
+        Number of loads {num_loads}''')),
+    'BestLocalRegAllocSimulation': format(
+        dedent('''\
+        OPT_SCHED LOCAL RA: DAG Name: {dag_name} Number of spills: {num_spills}
+        Number of stores {num_stores}
+        Number of loads {num_loads}''')),
+    'LocalRegAllocSimulationChoice': discard,
+    'PassFinished': discard, # lambda log: ('End of first pass through\n', 'End of second pass through')[log['num']],
+}
+
+
+def translate(infile, outfile):
+    lines = infile.readlines()
+    for line in lines:
+        if not line.startswith('EVENT:'):
+            outfile.write(line)
+            continue
+
+        parsed = json.loads(line.split(' ', 1)[1])
+        tr = TR_TABLE[parsed['event_id']]
+        print(tr(parsed), file=outfile)
+
+
+for inpath, outpath in zip(args.input, args.output):
+    with open(inpath, 'r') as infile,\
+        open(outpath, 'w') as outfile:
+        translate(infile, outfile)


### PR DESCRIPTION
Translates logs with the EVENT: + JSON format to the old INFO: format.

This is intended to be used for script verification purposes. An updated
script's results can be compared with the un-updated script by
translating the JSON logs and passing it through the older script.

----------

I still need to do more testing of this script.