### PR TITLE
Fixed bug in enumerator algorithm

### DIFF
--- a/include/opt-sched/Scheduler/enumerator.h
+++ b/include/opt-sched/Scheduler/enumerator.h
@@ -586,6 +586,8 @@ private:
   bool WasObjctvMet_();
   bool BackTrack_();
   InstCount GetBestCost_();
+  InstCount getBestSchedLength_();
+
   void CreateRootNode_();
 
   // Check if branching from the current node by scheduling this instruction

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -60,10 +60,15 @@ public:
   inline InstCount GetBestCost() { return bestCost_; }
   // Returns the heuristic cost for this region.
   inline InstCount GetHeuristicCost() { return hurstcCost_; }
+  // Return the spill cost for first pass of this region
+  inline InstCount getSpillCostConstraint() const { return HurstcSpillCost_; }
   // Returns a pointer to the list scheduler heurisitcs.
   inline SchedPriorities GetHeuristicPriorities() { return hurstcPrirts_; }
   // Get the number of simulated spills code added for this block.
   inline int GetSimSpills() { return totalSimSpills_; }
+
+  // Get the length of best schedule found so far
+  inline InstCount getBestSchedLength() { return bestSchedLngth_; }
 
   // TODO(max): Document.
   virtual FUNC_RESULT
@@ -106,6 +111,10 @@ public:
   void UpdateScheduleCost(InstSchedule *sched);
   SPILL_COST_FUNCTION GetSpillCostFunc();
 
+  void initTwoPassAlg();
+
+  bool isTwoPassEnabled() const { return TwoPassEnabled_; }
+
   bool IsSecondPass() const { return isSecondPass_; }
 
   // Initialize variables for the second pass of the two-pass-optsched
@@ -122,6 +131,9 @@ private:
   // The normal heuristic scheduling results.
   InstCount hurstcCost_;
 
+  // Spill cost for heuristic schedule
+  InstCount HurstcSpillCost_;
+
   // total simulated spills.
   int totalSimSpills_;
 
@@ -130,6 +142,9 @@ private:
 
   // Used for two-pass-optsched to enable second pass functionalies.
   bool isSecondPass_;
+
+  // Use for enable two-pass-optsched functionalities
+  bool TwoPassEnabled_;
 
   // The absolute cost lower bound to be used as a ref for normalized costs.
   InstCount costLwrBound_ = 0;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -864,7 +864,7 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
 
   if (crntCost < GetBestCost()) {
 
-    if (crntSched->GetCrntLngth() > schedLwrBound_)
+    if (crntSched->GetCrntLngth() > schedLwrBound_ && !(isTwoPassEnabled()))
       Logger::Info("$$$ GOOD_HIT: Better spill cost for a longer schedule");
 
     SetBestCost(crntCost);
@@ -873,7 +873,7 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
     enumBestSched_->Copy(crntSched);
     bestSched_ = enumBestSched_;
   }
-
+  
   return GetBestCost();
 }
 /*****************************************************************************/

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -433,6 +433,9 @@ void ScheduleDAGOptSched::schedule() {
   if (SecondPass)
     region->InitSecondPass();
 
+  if (TwoPassEnabled)
+    region->initTwoPassAlg();
+
   // Setup time before scheduling
   Utilities::startTime = std::chrono::high_resolution_clock::now();
   // Schedule region.


### PR DESCRIPTION
The intended logic of the two-pass algorithm is to find a good / optimal value of RP cost in the first pass, then iterate through minimum possible schedule lengths until we find a schedule that matches that predetermined RP cost.

Before this fix, the second pass would find the first pass' RP cost value for some schedule length, then continue to explore the rest of the tree for the given schedule length. Only after exploring to completion, or timing out, would the alg determine it had met the second pass' conditions. This additional exploring is wasted time as the conditions for finding good RP costs are worse in second pass compared to first pass, and I have seen no evidence that additional exploring in the second pass leads to better results. Further, in some cases, the additional exploring represents the overwhelming majority of second pass exploration (in the pic, the second pass finds desired schedule in 2ms, but continues exploring for another 235ms).

![Screenshot from 2020-09-24 15-19-08](https://user-images.githubusercontent.com/6306907/94343992-ecd6c500-ffd0-11ea-9077-b607d8525a3a.png)

This PR includes the code to stop exploring at the exact moment we find a min length schedule at the first pass' RP cost value.