### PR TITLE
Removal of weighted cost function for two-pass

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -189,6 +189,7 @@ REGIONS_TO_SCHEDULE fft1D_512:114
 
 # Whether to use suffix concatenation. Disabled automatically if
 # history domination is disabled.
+# WARNING: OUT OF DATE - GAURANTEED TO FAIL ON TWOPASS VERSION OF ALGORITHM
 ENABLE_SUFFIX_CONCATENATION NO
 
 # Whether to apply the node superiority graph transformation.

--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -32,8 +32,8 @@ struct Choice {
 class ACOScheduler : public ConstrainedScheduler {
 public:
   ACOScheduler(DataDepGraph *dataDepGraph, MachineModel *machineModel,
-               InstCount upperBound, SchedPriorities priorities,
-               bool vrfySched);
+               InstCount upperBound, SchedPriorities priorities, bool vrfySched,
+               bool IsPostBB);
   virtual ~ACOScheduler();
   FUNC_RESULT FindSchedule(InstSchedule *schedule, SchedRegion *region);
   inline void UpdtRdyLst_(InstCount cycleNum, int slotNum);
@@ -45,6 +45,7 @@ private:
   pheromone_t &Pheromone(SchedInstruction *from, SchedInstruction *to);
   pheromone_t &Pheromone(InstCount from, InstCount to);
   double Score(SchedInstruction *from, Choice choice);
+  bool shouldReplaceSchedule(InstSchedule *OldSched, InstSchedule *NewSched);
 
   void PrintPheromone();
 
@@ -80,9 +81,11 @@ private:
   double local_decay;
   double decay_factor;
   int ants_per_iteration;
+  int noImprovementMax;
   bool print_aco_trace;
   std::unique_ptr<InstSchedule> InitialSchedule;
   bool VrfySched_;
+  bool IsPostBB;
   pheromone_t ScRelMax;
 };
 

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -97,9 +97,10 @@ private:
   ConstrainedScheduler *AllocHeuristicScheduler_();
   bool EnableEnum_();
 
-  // BBWithSpill-specific Functions:
+  // BBWithSpill-specific Functions
   InstCount CmputCostLwrBound_(InstCount schedLngth);
   InstCount CmputCostLwrBound_();
+
   void InitForCostCmputtn_();
   InstCount CmputDynmcCost_();
 
@@ -120,10 +121,20 @@ public:
   ~BBWithSpill();
 
   int CmputCostLwrBound();
+  int cmputSpillCostLwrBound();
 
-  InstCount UpdtOptmlSched(InstSchedule *crntSched,
-                           LengthCostEnumerator *enumrtr);
+  std::vector<InstCount> UpdtOptmlSched(InstSchedule *crntSched,
+                                        LengthCostEnumerator *enumrtr);
+  std::vector<InstCount> UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
+                                               LengthCostEnumerator *enumrtr);
+  std::vector<InstCount> UpdtOptmlSchedScndPss(InstSchedule *crntSched,
+                                               LengthCostEnumerator *enumrtr);
+  std::vector<InstCount> UpdtOptmlSchedWghtd(InstSchedule *crntSched,
+                                             LengthCostEnumerator *enumrtr);
   bool ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *treeNode);
+  bool ChkCostFsbltyFrstPss(InstCount trgtLngth, EnumTreeNode *treeNode);
+  bool ChkCostFsbltyScndPss(InstCount trgtLngth, EnumTreeNode *treeNode);
+  bool ChkCostFsbltyWghtd(InstCount trgtLngth, EnumTreeNode *treeNode);
   void SchdulInst(SchedInstruction *inst, InstCount cycleNum, InstCount slotNum,
                   bool trackCnflcts);
   void UnschdulInst(SchedInstruction *inst, InstCount cycleNum,

--- a/include/opt-sched/Scheduler/bb_spill.h
+++ b/include/opt-sched/Scheduler/bb_spill.h
@@ -123,14 +123,14 @@ public:
   int CmputCostLwrBound();
   int cmputSpillCostLwrBound();
 
-  std::vector<InstCount> UpdtOptmlSched(InstSchedule *crntSched,
-                                        LengthCostEnumerator *enumrtr);
-  std::vector<InstCount> UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
-                                               LengthCostEnumerator *enumrtr);
-  std::vector<InstCount> UpdtOptmlSchedScndPss(InstSchedule *crntSched,
-                                               LengthCostEnumerator *enumrtr);
-  std::vector<InstCount> UpdtOptmlSchedWghtd(InstSchedule *crntSched,
-                                             LengthCostEnumerator *enumrtr);
+  SmallVector<InstCount, 4> UpdtOptmlSched(InstSchedule *crntSched,
+                                           LengthCostEnumerator *enumrtr);
+  SmallVector<InstCount, 4>
+  UpdtOptmlSchedFrstPss(InstSchedule *crntSched, LengthCostEnumerator *enumrtr);
+  SmallVector<InstCount, 4>
+  UpdtOptmlSchedScndPss(InstSchedule *crntSched, LengthCostEnumerator *enumrtr);
+  SmallVector<InstCount, 4> UpdtOptmlSchedWghtd(InstSchedule *crntSched,
+                                                LengthCostEnumerator *enumrtr);
   bool ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *treeNode);
   bool ChkCostFsbltyFrstPss(InstCount trgtLngth, EnumTreeNode *treeNode);
   bool ChkCostFsbltyScndPss(InstCount trgtLngth, EnumTreeNode *treeNode);

--- a/include/opt-sched/Scheduler/enumerator.h
+++ b/include/opt-sched/Scheduler/enumerator.h
@@ -150,9 +150,12 @@ private:
 
   InstCount cost_;
   InstCount costLwrBound_;
+  InstCount SpillCostLwrBound_;
   InstCount peakSpillCost_;
   InstCount spillCostSum_;
+  InstCount TotalSpillCost_ = -1;
   InstCount totalCost_ = -1;
+  InstCount SpillCost_;
   bool totalCostIsActualCost_ = false;
   ReserveSlot *rsrvSlots_;
 
@@ -270,11 +273,19 @@ public:
   inline void SetCostLwrBound(InstCount bound);
   inline InstCount GetCostLwrBound();
 
+  inline void setSpillCostLwrBound(InstCount bound) {
+    SpillCostLwrBound_ = bound;
+  }
+  inline InstCount getSpillCostLwrBound() const { return SpillCostLwrBound_; }
+
   inline void SetPeakSpillCost(InstCount cost);
   inline InstCount GetPeakSpillCost();
 
   inline void SetSpillCostSum(InstCount cost);
   inline InstCount GetSpillCostSum();
+
+  inline void setSpillCost(InstCount SpillCost);
+  inline InstCount getSpillCost();
 
   bool ChkInstRdndncy(SchedInstruction *inst, int brnchNum);
   bool IsNxtSlotStall();
@@ -284,12 +295,18 @@ public:
   int GetRealSlotNum() { return realSlotNum_; }
   void SetRealSlotNum(int num) { realSlotNum_ = num; }
 
+  inline InstCount getTotalSpillCost() const { return TotalSpillCost_; }
+  inline void setTotalSpillCost(InstCount TotalSpillCost) {
+    TotalSpillCost_ = TotalSpillCost;
+  }
+
   inline InstCount GetTotalCost() const { return totalCost_; }
   inline void SetTotalCost(InstCount totalCost) { totalCost_ = totalCost; }
 
   inline InstCount GetTotalCostIsActualCost() const {
     return totalCostIsActualCost_;
   }
+
   inline void SetTotalCostIsActualCost(bool totalCostIsActualCost) {
     totalCostIsActualCost_ = totalCostIsActualCost;
   }
@@ -327,6 +344,9 @@ protected:
 
   // The target length of which we are trying to find a feasible schedule
   InstCount trgtSchedLngth_;
+
+  // The target spill constraint we are trying to meet
+  InstCount TrgtSpillConstraint_;
 
   // A pointer to a relaxed scheduler
   RJ_RelaxedScheduler *rlxdSchdulr_;
@@ -407,6 +427,10 @@ protected:
   int imprvmntCnt_;
   InstCount prevTrgtLngth_;
 
+  // Algorithm type state variables
+  bool IsTwoPassEnabled_;
+  bool IsSecondPass_;
+
   LISTSCHED_HEURISTIC enumHurstc_;
 
   bool isEarlySubProbDom_;
@@ -484,6 +508,16 @@ protected:
   virtual void SetupAllocators_();
   virtual void FreeAllocators_();
   virtual void ResetAllocators_();
+
+  inline bool getIsTwoPass() { return IsTwoPassEnabled_; }
+  inline bool getIsSecondPass() { return IsSecondPass_; }
+
+  inline void setIsTwoPass(bool IsTwoPassEnabled) {
+    IsTwoPassEnabled_ = IsTwoPassEnabled;
+  }
+  inline void setIsSecondPass(bool IsSecondPass) {
+    IsSecondPass_ = IsSecondPass;
+  }
 
   void PrintLog_();
 
@@ -571,6 +605,7 @@ private:
   int costChkCnt_;
   int costPruneCnt_;
   int costLwrBound_;
+  int SpillCostLwrBound_;
   MemAlloc<CostHistEnumTreeNode> *histNodeAlctr_;
   SPILL_COST_FUNCTION spillCostFunc_;
 
@@ -584,8 +619,13 @@ private:
   void FreeHistNode_(HistEnumTreeNode *histNode);
 
   bool WasObjctvMet_();
+  bool WasObjctvMetWghtd_();
+  bool WasObjctvMetFrstPss_();
+  bool WasObjctvMetScndPss_();
   bool BackTrack_();
   InstCount GetBestCost_();
+  InstCount getBestSpillCost_();
+  InstCount getBestSchedLength_();
   void CreateRootNode_();
 
   // Check if branching from the current node by scheduling this instruction
@@ -616,6 +656,11 @@ public:
   bool IsCostEnum();
   SPILL_COST_FUNCTION GetSpillCostFunc() { return spillCostFunc_; }
   inline InstCount GetBestCost() { return GetBestCost_(); }
+  inline InstCount getBestSpillCost() { return getBestSpillCost_(); }
+  inline InstCount getBestSchedLength() { return getBestSchedLength_(); }
+
+  inline InstCount getTrgtLngth() { return trgtSchedLngth_; }
+  inline InstCount getTrgtSpillCostConstrnt() { return TrgtSpillConstraint_; }
 };
 /*****************************************************************************/
 
@@ -849,6 +894,15 @@ void EnumTreeNode::SetSpillCostSum(InstCount cost) {
 /*****************************************************************************/
 
 InstCount EnumTreeNode::GetSpillCostSum() { return spillCostSum_; }
+/*****************************************************************************/
+
+void EnumTreeNode::setSpillCost(InstCount SpillCost) {
+  assert(SpillCost >= 0);
+  SpillCost_ = SpillCost;
+}
+/*****************************************************************************/
+
+InstCount EnumTreeNode::getSpillCost() { return SpillCost_; }
 /*****************************************************************************/
 
 bool EnumTreeNode::IsNxtCycleNew_() {

--- a/include/opt-sched/Scheduler/graph_trans.h
+++ b/include/opt-sched/Scheduler/graph_trans.h
@@ -101,8 +101,8 @@ private:
 
   // Keep trying to find superior nodes until none can be found or there are no
   // more independent nodes.
-  void nodeMultiPass_(
-      std::list<std::pair<SchedInstruction *, SchedInstruction *>>);
+  void
+  nodeMultiPass_(std::list<std::pair<SchedInstruction *, SchedInstruction *>>);
 };
 
 } // namespace opt_sched

--- a/include/opt-sched/Scheduler/hist_table.h
+++ b/include/opt-sched/Scheduler/hist_table.h
@@ -115,13 +115,18 @@ protected:
   InstCount partialCost_ = -1;
   bool totalCostIsActualCost_ = false;
 
+  InstCount TotalSpillCost_ = -1;
+  InstCount PartialSpillCost_ = -1;
+
   bool isLngthFsbl_;
 #ifdef IS_DEBUG
   bool costInfoSet_;
 #endif
 
-  bool ChkCostDmntnForBBSpill_(EnumTreeNode *node, Enumerator *enumrtr);
-  bool ChkCostDmntn_(EnumTreeNode *node, Enumerator *enumrtr,
+  bool chkCostDmntnForSinglePass(EnumTreeNode *node,
+                                 LengthCostEnumerator *enumrtr);
+  bool chkCostDmntnForTwoPass(EnumTreeNode *Node, LengthCostEnumerator *E);
+  bool ChkCostDmntn_(EnumTreeNode *node, LengthCostEnumerator *enumrtr,
                      InstCount &maxShft);
   virtual void Init_();
 };

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -90,18 +90,18 @@ public:
   virtual int cmputSpillCostLwrBound() = 0;
 
   // TODO(max): Document.
-  virtual std::vector<InstCount>
+  virtual llvm::SmallVector<InstCount, 4>
   UpdtOptmlSched(InstSchedule *crntSched, LengthCostEnumerator *enumrtr) = 0;
 
-  virtual std::vector<InstCount>
+  virtual llvm::SmallVector<InstCount, 4>
   UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
                         LengthCostEnumerator *enumrtr) = 0;
 
-  virtual std::vector<InstCount>
+  virtual llvm::SmallVector<InstCount, 4>
   UpdtOptmlSchedScndPss(InstSchedule *crntSched,
                         LengthCostEnumerator *enumrtr) = 0;
 
-  virtual std::vector<InstCount>
+  virtual llvm::SmallVector<InstCount, 4>
   UpdtOptmlSchedWghtd(InstSchedule *crntSched,
                       LengthCostEnumerator *enumrtr) = 0;
 

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -855,8 +855,9 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds startTime,
 }
 /*****************************************************************************/
 
-std::vector<InstCount> BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
-                                                   LengthCostEnumerator *node) {
+SmallVector<InstCount, 4>
+BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
+                            LengthCostEnumerator *node) {
 
   if (isTwoPassEnabled()) {
     if (!IsSecondPass())
@@ -871,14 +872,13 @@ std::vector<InstCount> BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
 
 /*****************************************************************************/
 
-std::vector<InstCount>
+SmallVector<InstCount, 4>
 BBWithSpill::UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
                                    LengthCostEnumerator *) {
   InstCount crntCost;
   InstCount crntExecCost;
   InstCount TmpSpillCost;
-  // llvm::SmallVector<InstCount, 4> retVec;
-  std::vector<InstCount> retVec;
+  llvm::SmallVector<InstCount, 4> retVec;
 
   //  crntCost = CmputNormCost_(crntSched, CCM_DYNMC, crntExecCost, false);
   crntCost = CmputNormCost_(crntSched, CCM_STTC, crntExecCost, false);
@@ -908,14 +908,13 @@ BBWithSpill::UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
 
 /*****************************************************************************/
 
-std::vector<InstCount>
+SmallVector<InstCount, 4>
 BBWithSpill::UpdtOptmlSchedScndPss(InstSchedule *crntSched,
                                    LengthCostEnumerator *) {
   InstCount crntCost;
   InstCount crntExecCost;
   InstCount TmpSpillCost;
-  // llvm::SmallVector<InstCount,4> retVec;
-  std::vector<InstCount> retVec;
+  llvm::SmallVector<InstCount, 4> retVec;
 
   //  crntCost = CmputNormCost_(crntSched, CCM_DYNMC, crntExecCost, false);
   crntCost = CmputNormCost_(crntSched, CCM_STTC, crntExecCost, false);
@@ -946,11 +945,10 @@ BBWithSpill::UpdtOptmlSchedScndPss(InstSchedule *crntSched,
 
 /*****************************************************************************/
 
-std::vector<InstCount>
+SmallVector<InstCount, 4>
 BBWithSpill::UpdtOptmlSchedWghtd(InstSchedule *crntSched,
                                  LengthCostEnumerator *) {
-  // llvm::SmallVector<InstCount,4> retVec;
-  std::vector<InstCount> retVec;
+  llvm::SmallVector<InstCount, 4> retVec;
 
   InstCount crntCost;
   InstCount crntExecCost;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -288,21 +288,15 @@ static InstCount ComputeSLILStaticLowerBound(int64_t regTypeCnt_,
 /*****************************************************************************/
 
 InstCount BBWithSpill::CmputCostLwrBound() {
-  InstCount spillCostLwrBound = 0;
-
-  if (GetSpillCostFunc() == SCF_SLIL) {
-    spillCostLwrBound =
-        ComputeSLILStaticLowerBound(regTypeCnt_, regFiles_, dataDepGraph_);
-    dynamicSlilLowerBound_ = spillCostLwrBound;
-    staticSlilLowerBound_ = spillCostLwrBound;
-  }
+  InstCount SpillCostLwrBound = cmputSpillCostLwrBound();
+  setSpillCostLwrBound(SpillCostLwrBound);
 
   // for(InstCount i=0; i< dataDepGraph_->GetInstCnt(); i++) {
   //   inst = dataDepGraph_->GetInstByIndx(i);
   // }
 
   InstCount staticLowerBound =
-      schedLwrBound_ * schedCostFactor_ + spillCostLwrBound * SCW_;
+      schedLwrBound_ * schedCostFactor_ + SpillCostLwrBound * SCW_;
 
 #if defined(IS_DEBUG_STATIC_LOWER_BOUND)
   Logger::Event("StaticLowerBoundDebugInfo", "name", dataDepGraph_->GetDagID(),
@@ -312,6 +306,19 @@ InstCount BBWithSpill::CmputCostLwrBound() {
 #endif
 
   return staticLowerBound;
+}
+
+InstCount BBWithSpill::cmputSpillCostLwrBound() {
+  InstCount spillCostLwrBound = 0;
+
+  if (GetSpillCostFunc() == SCF_SLIL) {
+    spillCostLwrBound =
+        ComputeSLILStaticLowerBound(regTypeCnt_, regFiles_, dataDepGraph_);
+    dynamicSlilLowerBound_ = spillCostLwrBound;
+    staticSlilLowerBound_ = spillCostLwrBound;
+  }
+
+  return spillCostLwrBound;
 }
 /*****************************************************************************/
 
@@ -779,6 +786,7 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds startTime,
   FUNC_RESULT rslt = RES_SUCCESS;
   int iterCnt = 0;
   int costLwrBound = 0;
+  // int SpillCostLwrBound = cmputSpillCostLwrBound();
   bool timeout = false;
 
   Milliseconds rgnDeadline, lngthDeadline;
@@ -847,8 +855,103 @@ FUNC_RESULT BBWithSpill::Enumerate_(Milliseconds startTime,
 }
 /*****************************************************************************/
 
-InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
-                                      LengthCostEnumerator *) {
+std::vector<InstCount> BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
+                                                   LengthCostEnumerator *node) {
+
+  if (isTwoPassEnabled()) {
+    if (!IsSecondPass())
+      return UpdtOptmlSchedFrstPss(crntSched, node);
+    else
+      return UpdtOptmlSchedScndPss(crntSched, node);
+  }
+
+  else
+    return UpdtOptmlSchedWghtd(crntSched, node);
+}
+
+/*****************************************************************************/
+
+std::vector<InstCount>
+BBWithSpill::UpdtOptmlSchedFrstPss(InstSchedule *crntSched,
+                                   LengthCostEnumerator *) {
+  InstCount crntCost;
+  InstCount crntExecCost;
+  InstCount TmpSpillCost;
+  // llvm::SmallVector<InstCount, 4> retVec;
+  std::vector<InstCount> retVec;
+
+  //  crntCost = CmputNormCost_(crntSched, CCM_DYNMC, crntExecCost, false);
+  crntCost = CmputNormCost_(crntSched, CCM_STTC, crntExecCost, false);
+
+  //#ifdef IS_DEBUG_SOLN_DETAILS_2
+  Logger::Info(
+      "Found a feasible sched. of length %d, spill cost %d and tot cost %d",
+      crntSched->GetCrntLngth(), crntSched->GetSpillCost(), crntCost);
+  //  crntSched->Print(Logger::GetLogStream(), "New Feasible Schedule");
+  //#endif
+
+  TmpSpillCost =
+      GetSpillCostFunc() == SCF_SLIL ? dynamicSlilLowerBound_ : crntSpillCost_;
+
+  if (TmpSpillCost < getBestSpillCost()) {
+    SetBestCost(crntCost);
+    optmlSpillCost_ = TmpSpillCost;
+    setBestSpillCost(optmlSpillCost_);
+    SetBestSchedLength(crntSched->GetCrntLngth());
+    enumBestSched_->Copy(crntSched);
+    bestSched_ = enumBestSched_;
+  }
+
+  retVec.push_back(TmpSpillCost);
+  return retVec;
+}
+
+/*****************************************************************************/
+
+std::vector<InstCount>
+BBWithSpill::UpdtOptmlSchedScndPss(InstSchedule *crntSched,
+                                   LengthCostEnumerator *) {
+  InstCount crntCost;
+  InstCount crntExecCost;
+  InstCount TmpSpillCost;
+  // llvm::SmallVector<InstCount,4> retVec;
+  std::vector<InstCount> retVec;
+
+  //  crntCost = CmputNormCost_(crntSched, CCM_DYNMC, crntExecCost, false);
+  crntCost = CmputNormCost_(crntSched, CCM_STTC, crntExecCost, false);
+
+  //#ifdef IS_DEBUG_SOLN_DETAILS_2
+  Logger::Info(
+      "Found a feasible sched. of length %d, spill cost %d and tot cost %d",
+      crntSched->GetCrntLngth(), crntSched->GetSpillCost(), crntCost);
+  //  crntSched->Print(Logger::GetLogStream(), "New Feasible Schedule");
+  //#endif
+
+  TmpSpillCost =
+      GetSpillCostFunc() == SCF_SLIL ? dynamicSlilLowerBound_ : crntSpillCost_;
+
+  if (TmpSpillCost <= getSpillCostConstraint()) {
+    SetBestCost(crntCost);
+    optmlSpillCost_ = TmpSpillCost;
+    setBestSpillCost(optmlSpillCost_);
+    SetBestSchedLength(crntSched->GetCrntLngth());
+    enumBestSched_->Copy(crntSched);
+    bestSched_ = enumBestSched_;
+  }
+
+  retVec.push_back(TmpSpillCost);
+  retVec.push_back(crntSched->GetCrntLngth());
+  return retVec;
+}
+
+/*****************************************************************************/
+
+std::vector<InstCount>
+BBWithSpill::UpdtOptmlSchedWghtd(InstSchedule *crntSched,
+                                 LengthCostEnumerator *) {
+  // llvm::SmallVector<InstCount,4> retVec;
+  std::vector<InstCount> retVec;
+
   InstCount crntCost;
   InstCount crntExecCost;
 
@@ -874,8 +977,10 @@ InstCount BBWithSpill::UpdtOptmlSched(InstSchedule *crntSched,
     bestSched_ = enumBestSched_;
   }
 
-  return GetBestCost();
+  retVec.push_back(crntCost);
+  return retVec;
 }
+
 /*****************************************************************************/
 
 void BBWithSpill::SetupForSchdulng_() {
@@ -901,30 +1006,125 @@ void BBWithSpill::SetupForSchdulng_() {
 
 bool BBWithSpill::ChkCostFsblty(InstCount trgtLngth, EnumTreeNode *node) {
   bool fsbl = true;
-  InstCount crntCost, dynmcCostLwrBound;
+
+  if (isTwoPassEnabled()) {
+    if (!IsSecondPass())
+      fsbl = ChkCostFsbltyFrstPss(trgtLngth, node);
+    else
+      fsbl = ChkCostFsbltyScndPss(trgtLngth, node);
+  }
+
+  else
+    fsbl = ChkCostFsbltyWghtd(trgtLngth, node);
+
+  return fsbl;
+}
+
+/*****************************************************************************/
+
+bool BBWithSpill::ChkCostFsbltyFrstPss(InstCount trgtLngth,
+                                       EnumTreeNode *node) {
+  bool fsbl;
+  InstCount TmpSpillCost;
+
+  InstCount crntCost;
+  if (GetSpillCostFunc() == SCF_SLIL) {
+    TmpSpillCost = dynamicSlilLowerBound_;
+    // this line currently needed for hist dom
+    crntCost = dynamicSlilLowerBound_ * SCW_ + trgtLngth * schedCostFactor_;
+    fsbl = dynamicSlilLowerBound_ < getBestSpillCost();
+  }
+
+  else {
+    TmpSpillCost = crntSpillCost_;
+    crntCost = crntSpillCost_ * SCW_ + trgtLngth * schedCostFactor_;
+    fsbl = crntSpillCost_ < getBestSpillCost();
+  }
+
+  crntCost -= GetCostLwrBound();
+
+  // assert(cost >= 0);
+  assert(crntCost >= 0);
+
+  if (fsbl) {
+    node->SetCost(crntCost);
+    node->SetCostLwrBound(crntCost);
+    node->SetPeakSpillCost(peakSpillCost_);
+    node->SetSpillCostSum(totSpillCost_);
+    node->setSpillCost(TmpSpillCost);
+    node->setSpillCostLwrBound(TmpSpillCost);
+  }
+
+  return fsbl;
+}
+
+/*****************************************************************************/
+
+bool BBWithSpill::ChkCostFsbltyScndPss(InstCount trgtLngth,
+                                       EnumTreeNode *node) {
+  InstCount TmpSpillCost;
+  InstCount crntCost;
+
   if (GetSpillCostFunc() == SCF_SLIL) {
     crntCost = dynamicSlilLowerBound_ * SCW_ + trgtLngth * schedCostFactor_;
+    TmpSpillCost = dynamicSlilLowerBound_;
+  }
+
+  else {
+    crntCost = crntSpillCost_ * SCW_ + trgtLngth * schedCostFactor_;
+    TmpSpillCost = crntSpillCost_;
+  }
+
+  crntCost -= GetCostLwrBound();
+
+  // assert(cost >= 0);
+  assert(crntCost >= 0);
+
+  if (TmpSpillCost <= getSpillCostConstraint()) {
+    node->SetCost(crntCost);
+    node->SetCostLwrBound(crntCost);
+    node->SetPeakSpillCost(peakSpillCost_);
+    node->SetSpillCostSum(totSpillCost_);
+    node->setSpillCost(TmpSpillCost);
+    node->setSpillCostLwrBound(TmpSpillCost);
+    return true;
+  }
+
+  return false;
+}
+
+/*****************************************************************************/
+
+bool BBWithSpill::ChkCostFsbltyWghtd(InstCount trgtLngth, EnumTreeNode *node) {
+  bool fsbl = true;
+  InstCount crntCost, TmpSpillCost;
+  if (GetSpillCostFunc() == SCF_SLIL) {
+    TmpSpillCost = dynamicSlilLowerBound_;
+    crntCost = dynamicSlilLowerBound_ * SCW_ + trgtLngth * schedCostFactor_;
   } else {
+    TmpSpillCost = crntSpillCost_;
     crntCost = crntSpillCost_ * SCW_ + trgtLngth * schedCostFactor_;
   }
   crntCost -= GetCostLwrBound();
-  dynmcCostLwrBound = crntCost;
 
   // assert(cost >= 0);
-  assert(dynmcCostLwrBound >= 0);
+  assert(crntCost >= 0);
 
-  fsbl = dynmcCostLwrBound < GetBestCost();
+  fsbl = crntCost < GetBestCost();
 
   // FIXME: RP tracking should be limited to the current SCF. We need RP
   // tracking interface.
   if (fsbl) {
     node->SetCost(crntCost);
-    node->SetCostLwrBound(dynmcCostLwrBound);
+    node->SetCostLwrBound(crntCost);
     node->SetPeakSpillCost(peakSpillCost_);
     node->SetSpillCostSum(totSpillCost_);
+    node->setSpillCost(TmpSpillCost);
+    node->setSpillCostLwrBound(TmpSpillCost);
   }
   return fsbl;
 }
+
 /*****************************************************************************/
 
 void BBWithSpill::SetSttcLwrBounds(EnumTreeNode *) {

--- a/lib/Scheduler/enumerator.cpp
+++ b/lib/Scheduler/enumerator.cpp
@@ -2076,7 +2076,7 @@ bool LengthCostEnumerator::WasObjctvMet_() {
 
 bool LengthCostEnumerator::WasObjctvMetWghtd_() {
   // llvm::SmallVector<InstCount,4> ObjctvValues;
-  std::vector<InstCount> ObjctvValues;
+  llvm::SmallVector<InstCount, 4> ObjctvValues;
 
   InstCount crntCost = GetBestCost_();
 
@@ -2091,7 +2091,7 @@ bool LengthCostEnumerator::WasObjctvMetWghtd_() {
 
 bool LengthCostEnumerator::WasObjctvMetFrstPss_() {
   // llvm::SmallVector<InstCount,4> ObjctvValues;
-  std::vector<InstCount> ObjctvValues;
+  llvm::SmallVector<InstCount, 4> ObjctvValues;
 
   InstCount crntSpillCost = getBestSpillCost_();
 
@@ -2106,7 +2106,7 @@ bool LengthCostEnumerator::WasObjctvMetFrstPss_() {
 
 bool LengthCostEnumerator::WasObjctvMetScndPss_() {
   // llvm::SmallVector<InstCount,4> ObjctvValues;
-  std::vector<InstCount> ObjctvValues;
+  llvm::SmallVector<InstCount, 4> ObjctvValues;
 
   InstCount crntSchedLength = getBestSchedLength_();
 
@@ -2204,7 +2204,10 @@ bool LengthCostEnumerator::BackTrack_() {
       if (!rgn_->isTwoPassEnabled())
         fsbl = crntNode_->GetCostLwrBound() < GetBestCost_();
       else {
-        fsbl = crntNode_->getSpillCostLwrBound() < getBestSpillCost();
+        if (!rgn_->IsSecondPass())
+          fsbl = crntNode_->getSpillCostLwrBound() < getBestSpillCost();
+        else
+          fsbl = crntNode_->getSpillCostLwrBound() <= getBestSpillCost();
       }
     }
   }

--- a/lib/Scheduler/hist_table.cpp
+++ b/lib/Scheduler/hist_table.cpp
@@ -404,37 +404,41 @@ void CostHistEnumTreeNode::Init_() {
 
 bool CostHistEnumTreeNode::DoesDominate(EnumTreeNode *node,
                                         Enumerator *enumrtr) {
+#ifdef IS_DEBUG
   assert(isCnstrctd_);
+#endif
   assert(enumrtr->IsCostEnum());
 
   InstCount shft = 0;
 
   // If the history node does not dominate the current node, we cannot
   // draw any conclusion and no pruning can be done.
+  if (DoesDominate_(node, NULL, ETN_ACTIVE, enumrtr, shft) == false)
+    return false;
 
-  // (Chris): If scheduling for RP only, automatically assume all nodes are
-  // feasible and just check for cost domination.
-  if (!enumrtr->IsSchedForRPOnly()) {
-    if (DoesDominate_(node, NULL, ETN_ACTIVE, enumrtr, shft) == false)
-      return false;
-
-    // if the history node dominates the current node, and there is
-    // no feasible sched below the hist node, there cannot be a feasible
-    // sched below the current node. So, prune the current node
-    if (isLngthFsbl_ == false)
-      return true;
-  }
+  // if the history node dominates the current node, and there is
+  // no feasible sched below the hist node, there cannot be a feasible
+  // sched below the current node. So, prune the current node
+  if (isLngthFsbl_ == false)
+    return true;
 
   // if the hist node dominates the current node, and the hist node
   // had at least one feasible sched below it, domination will be
   // determined by the cost domination condition
-  return ChkCostDmntn_(node, enumrtr, shft);
+  auto *LCE = static_cast<LengthCostEnumerator *>(enumrtr);
+  return ChkCostDmntn_(node, LCE, shft);
 }
 
 bool CostHistEnumTreeNode::ChkCostDmntn_(EnumTreeNode *node,
-                                         Enumerator *enumrtr,
+                                         LengthCostEnumerator *LCE,
                                          InstCount &maxShft) {
-  return ChkCostDmntnForBBSpill_(node, enumrtr);
+  // If two pass is enabled then call the two pass cost specific history
+  // domination check
+  if (LCE->getIsTwoPass())
+    return chkCostDmntnForTwoPass(node, LCE);
+
+  // Run default weighted sum history domination check
+  return chkCostDmntnForSinglePass(node, LCE);
 }
 
 // For the SLIL cost function the improvement in cost when comparing the other
@@ -450,6 +454,26 @@ static bool doesHistorySLILCostDominate(InstCount OtherPrefixCost,
   return ImprovementOnHistory <= RequiredImprovement;
 }
 
+static bool doesHistorySLILCostDominateFrstPss(InstCount OtherPrefixSpillCost,
+                                               InstCount HistPrefixSpillCost,
+                                               InstCount HistTotalSpillCost,
+                                               LengthCostEnumerator *LCE) {
+  auto RequiredImprovement =
+      std::max(HistTotalSpillCost - LCE->getBestSpillCost(), 0);
+  auto ImprovementOnHistory = HistPrefixSpillCost - OtherPrefixSpillCost;
+  return ImprovementOnHistory <= RequiredImprovement;
+}
+
+static bool doesHistorySLILCostDominateScndPss(InstCount OtherPrefixSpillCost,
+                                               InstCount HistPrefixSpillCost,
+                                               InstCount HistTotalSpillCost,
+                                               LengthCostEnumerator *LCE) {
+  auto RequiredImprovement =
+      std::max(HistTotalSpillCost - LCE->getTrgtSpillCostConstrnt(), 0);
+  auto ImprovementOnHistory = HistPrefixSpillCost - OtherPrefixSpillCost;
+  return ImprovementOnHistory <= RequiredImprovement;
+}
+
 // For peak cost functions (PERP, PRP, Occupancy) the suffix cost does not
 // depend on the prefix cost.
 static bool doesHistoryPeakCostDominate(InstCount OtherPrefixCost,
@@ -459,6 +483,7 @@ static bool doesHistoryPeakCostDominate(InstCount OtherPrefixCost,
   // If we cannot improve the prefix, prune the candidate node. Likewise, if
   // the total cost is determined by the suffix schedule we cannot improve the
   // cost with a better prefix.
+
   if (OtherPrefixCost >= HistPrefixCost || HistTotalCost > HistPrefixCost)
     return true;
 
@@ -467,33 +492,97 @@ static bool doesHistoryPeakCostDominate(InstCount OtherPrefixCost,
   return LCE->GetBestCost() <= OtherPrefixCost;
 }
 
+// First pass simply compares current to history RP
+static bool doesHistoryPeakCostDominateFrstPss(InstCount OtherPrefixSpillCost,
+                                               InstCount HistPrefixSpillCost,
+                                               InstCount HistTotalSpillCost,
+                                               LengthCostEnumerator *LCE) {
+  if (OtherPrefixSpillCost >= HistPrefixSpillCost ||
+      HistTotalSpillCost > HistPrefixSpillCost)
+    return true;
+
+  return LCE->getBestSpillCost() <= OtherPrefixSpillCost;
+}
+
+static bool doesHistoryPeakCostDominateScndPss(InstCount OtherPrefixSpillCost,
+                                               InstCount HistPrefixSpillCost,
+                                               InstCount HistTotalSpillCost,
+                                               LengthCostEnumerator *LCE) {
+
+  // After propogating RP values for probed nodes that fail RP checks, this
+  // check will likely due more pruning
+  if (HistTotalSpillCost > LCE->getTrgtSpillCostConstrnt() &&
+      HistTotalSpillCost > HistPrefixSpillCost)
+    return true;
+
+  // Check if prefix is within RP constraint
+  return OtherPrefixSpillCost > LCE->getTrgtSpillCostConstrnt();
+}
+
 // Should we prune the other node based on RP cost.
-bool CostHistEnumTreeNode::ChkCostDmntnForBBSpill_(EnumTreeNode *Node,
-                                                   Enumerator *E) {
+bool CostHistEnumTreeNode::chkCostDmntnForTwoPass(EnumTreeNode *Node,
+                                                  LengthCostEnumerator *LCE) {
   if (time_ > Node->GetTime())
     return false;
 
+#ifdef IS_DEBUG
+  assert(costInfoSet_);
+#endif
+
+  bool ShouldPrune = false;
+  SPILL_COST_FUNCTION SpillCostFunc = LCE->GetSpillCostFunc();
+
+  if (SpillCostFunc == SCF_TARGET || SpillCostFunc == SCF_PRP ||
+      SpillCostFunc == SCF_PERP) {
+    if (LCE->getIsSecondPass())
+      ShouldPrune = doesHistoryPeakCostDominateScndPss(
+          Node->getSpillCost(), PartialSpillCost_, TotalSpillCost_, LCE);
+    else
+      ShouldPrune = doesHistoryPeakCostDominateFrstPss(
+          Node->getSpillCost(), PartialSpillCost_, TotalSpillCost_, LCE);
+  }
+
+  else if (SpillCostFunc == SCF_SLIL) {
+
+    if (LCE->getIsSecondPass())
+      ShouldPrune = doesHistorySLILCostDominateScndPss(
+          Node->getSpillCost(), PartialSpillCost_, TotalSpillCost_, LCE);
+    else
+      ShouldPrune = doesHistorySLILCostDominateFrstPss(
+          Node->getSpillCost(), PartialSpillCost_, TotalSpillCost_, LCE);
+  }
+
+  return ShouldPrune;
+}
+
+// Should we prune the other node based on RP cost.
+bool CostHistEnumTreeNode::chkCostDmntnForSinglePass(EnumTreeNode *Node,
+                                                     LengthCostEnumerator *E) {
+  if (time_ > Node->GetTime())
+    return false;
+
+#ifdef IS_DEBUG
+  assert(costInfoSet_);
+#endif
   // If the other node's prefix cost is higher than or equal to the history
   // prefix cost the other node is pruned.
-  assert(costInfoSet_);
   bool ShouldPrune;
   if (Node->GetCostLwrBound() >= partialCost_)
     ShouldPrune = true;
   else {
     ShouldPrune = false;
-    LengthCostEnumerator *LCE = static_cast<LengthCostEnumerator *>(E);
-    SPILL_COST_FUNCTION SpillCostFunc = LCE->GetSpillCostFunc();
+    SPILL_COST_FUNCTION SpillCostFunc = E->GetSpillCostFunc();
 
     // We cannot prune based on prefix cost, but check for more aggressive
     // pruning conditions that are specific to the current cost function.
     if (SpillCostFunc == SCF_TARGET || SpillCostFunc == SCF_PRP ||
         SpillCostFunc == SCF_PERP)
       ShouldPrune = doesHistoryPeakCostDominate(Node->GetCostLwrBound(),
-                                                partialCost_, totalCost_, LCE);
+                                                partialCost_, totalCost_, E);
 
     else if (SpillCostFunc == SCF_SLIL)
       ShouldPrune = doesHistorySLILCostDominate(Node->GetCostLwrBound(),
-                                                partialCost_, totalCost_, LCE);
+                                                partialCost_, totalCost_, E);
 
     // If the cost function is peak plus avg, make sure that the fraction lost
     // by integer divsion does not lead to false domination.
@@ -516,6 +605,10 @@ void CostHistEnumTreeNode::SetCostInfo(EnumTreeNode *node, bool, Enumerator *) {
   partialCost_ = node->GetCostLwrBound();
   totalCost_ = node->GetTotalCost();
   totalCostIsActualCost_ = node->GetTotalCostIsActualCost();
+
+  PartialSpillCost_ = node->getSpillCost();
+  TotalSpillCost_ = node->getTotalSpillCost();
+
   if (suffix_ == nullptr && node->GetSuffix().size() > 0)
     suffix_ =
         std::make_shared<std::vector<SchedInstruction *>>(node->GetSuffix());

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -429,7 +429,7 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     Milliseconds enumStart = Utilities::GetProcessorTime();
     if (!isLstOptml) {
       dataDepGraph_->SetHard(true);
-      if ((IsSecondPass() && dataDepGraph_->GetMaxLtncy() <= 1))
+      if (IsSecondPass() && dataDepGraph_->GetMaxLtncy() <= 1)
         Logger::Info("Problem size not increased after introducing latencies, "
                      "skipping enumeration");
       else

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -430,8 +430,11 @@ void ScheduleDAGOptSched::schedule() {
   }
 
   // Used for two-pass-optsched to alter upper bound value.
-  if (SecondPass)
-    region->InitSecondPass();
+  if (isTwoPassEnabled()) {
+    region->initTwoPassAlg();
+    if (SecondPass)
+      region->InitSecondPass();
+  }
 
   // Setup time before scheduling
   Utilities::startTime = std::chrono::high_resolution_clock::now();

--- a/util/CPU2006/runspec-wrapper-optsched.py
+++ b/util/CPU2006/runspec-wrapper-optsched.py
@@ -19,177 +19,469 @@ from readlogs import *
 
 # Dictionary for benchmark selection. Maps benchmark names and categories
 # to lists of specific benchmarks.
-benchDict = {}
-# Add all benchmarks individually.
-benchDict['perlbench'] = ['perlbench']
-benchDict['bzip2'] = ['bzip2']
-benchDict['gcc'] = ['gcc']
-benchDict['mcf'] = ['mcf']
-benchDict['gobmk'] = ['gobmk']
-benchDict['hmmer'] = ['hmmer']
-benchDict['sjeng'] = ['sjeng']
-benchDict['libquantum'] = ['libquantum']
-benchDict['h264ref'] = ['h264ref']
-benchDict['omnetpp'] = ['omnetpp']
-benchDict['astar'] = ['astar']
-benchDict['xalancbmk'] = ['xalancbmk']
-benchDict['bwaves'] = ['bwaves']
-benchDict['gamess'] = ['gamess']
-benchDict['milc'] = ['milc']
-benchDict['zeusmp'] = ['zeusmp']
-benchDict['gromacs'] = ['gromacs']
-benchDict['cactus'] = ['cactus']
-benchDict['leslie'] = ['leslie']
-benchDict['namd'] = ['namd']
-benchDict['dealII'] = ['dealII']
-benchDict['soplex'] = ['soplex']
-benchDict['povray'] = ['povray']
-benchDict['calculix'] = ['calculix']
-benchDict['Gems'] = ['Gems']
-benchDict['tonto'] = ['tonto']
-benchDict['lbm'] = ['lbm']
-benchDict['wrf'] = ['wrf']
-benchDict['sphinx'] = ['sphinx']
+specVersions = {
+    'CPU2006' : {
+        'BUILD_COMMAND' : 'runspec --loose -size=ref -iterations=1 -config=%s --tune=base -r 1 -I -a build %s',
+        'SCRUB_COMMAND' : 'runspec --loose -size=ref -iterations=1 -config=%s --tune=base -r 1 -I -a scrub %s',
+        'benchDict' : {
+            # Add all benchmarks individually.
+            'perlbench': ['perlbench'],
+            'bzip2' : ['bzip2'],
+            'gcc' : ['gcc'],
+            'mcf' : ['mcf'],
+            'gobmk' : ['gobmk'],
+            'hmmer' : ['hmmer'],
+            'sjeng' : ['sjeng'],
+            'libquantum' : ['libquantum'],
+            'h264ref' : ['h264ref'],
+            'omnetpp' : ['omnetpp'],
+            'astar' : ['astar'],
+            'xalancbmk' : ['xalancbmk'],
+            'bwaves' : ['bwaves'],
+            'gamess' : ['gamess'],
+            'milc' : ['milc'],
+            'zeusmp' : ['zeusmp'],
+            'gromacs' : ['gromacs'],
+            'cactus' : ['cactus'],
+            'leslie' : ['leslie'],
+            'namd' : ['namd'],
+            'dealII' : ['dealII'],
+            'soplex' : ['soplex'],
+            'povray' : ['povray'],
+            'calculix' : ['calculix'],
+            'Gems' : ['Gems'],
+            'tonto' : ['tonto'],
+            'lbm' : ['lbm'],
+            'wrf' : ['wrf'],
 
-# Add ALL benchmark group.
-benchDict['ALL'] = [
-    'perlbench',
-    'bzip2',
-    'gcc',
-    'mcf',
-    'gobmk',
-    'hmmer',
-    'sjeng',
-    'libquantum',
-    'h264ref',
-    'omnetpp',
-    'astar',
-    'xalancbmk',
-    'bwaves',
-    'gamess',
-    'milc',
-    'zeusmp',
-    'gromacs',
-    'cactus',
-    'leslie', 'namd',
-    'dealII',
-    'soplex',
-    'povray',
-    'calculix',
-    'Gems',
-    'tonto',
-    'lbm',
-    'wrf',
-    'sphinx'
-]
+            # Add ALL benchmark group.
+            'ALL' : [
+                'perlbench',
+                'bzip2',
+                'gcc',
+                'mcf',
+                'gobmk',
+                'hmmer',
+                'sjeng',
+                'libquantum',
+                'h264ref',
+                'omnetpp',
+                'astar',
+                'xalancbmk',
+                'bwaves',
+                'gamess',
+                'milc',
+                'zeusmp',
+                'gromacs',
+                'cactus',
+                'leslie',
+                'namd',
+                'dealII',
+                'soplex',
+                'povray',
+                'calculix',
+                'Gems',
+                'tonto',
+                'lbm',
+                'wrf',
+                'sphinx'
+            ],
 
-# Add INT benchmark group.
-benchDict['INT'] = [
-    'perlbench',
-    'bzip2',
-    'gcc',
-    'mcf',
-    'gobmk',
-    'hmmer',
-    'sjeng',
-    'libquantum',
-    'h264ref',
-    'omnetpp',
-    'astar',
-    'xalancbmk'
-]
+            # Add INT benchmark group.
+            'INT' : [
+                'perlbench',
+                'bzip2',
+                'gcc',
+                'mcf',
+                'gobmk',
+                'hmmer',
+                'sjeng',
+                'libquantum',
+                'h264ref',
+                'omnetpp',
+                'astar',
+                'xalancbmk'
+            ],
 
-# Add FP benchmark group.
-benchDict['FP'] = [
-    'bwaves',
-    'gamess',
-    'milc',
-    'zeusmp',
-    'gromacs',
-    'cactus',
-    'leslie',
-    'namd',
-    'dealII',
-    'soplex',
-    'povray',
-    'calculix',
-    'Gems',
-    'tonto',
-    'lbm',
-    'wrf',
-    'sphinx'
-]
+            # Add FP benchmark group.
+            'FP' : [
+                'bwaves',
+                'gamess',
+                'milc',
+                'zeusmp',
+                'gromacs',
+                'cactus',
+                'leslie',
+                'namd',
+                'dealII',
+                'soplex',
+                'povray',
+                'calculix',
+                'Gems',
+                'tonto',
+                'lbm',
+                'wrf',
+                'sphinx'
+            ],
 
-# Add C benchmark group.
-benchDict['C'] = [
-    'perlbench',
-    'bzip2',
-    'gcc',
-    'mcf',
-    'milc',
-    'gobmk',
-    'hmmer',
-    'sjeng',
-    'libquantum',
-    'h264ref',
-    'lbm',
-    'sphinx'
-]
+            # Add C benchmark group.
+            'C' : [
+                'perlbench',
+                'bzip2',
+                'gcc',
+                'mcf',
+                'milc',
+                'gobmk',
+                'hmmer',
+                'sjeng',
+                'libquantum',
+                'h264ref',
+                'lbm',
+                'sphinx'
+            ],
 
-# Add C++ benchmark group.
-benchDict['C++'] = [
-    'namd',
-    'dealII',
-    'soplex',
-    'povray',
-    'omnetpp',
-    'astar',
-    'xalancbmk'
-]
+            # Add C++ benchmark group.
+            'C++' : [
+                'namd',
+                'dealII',
+                'soplex',
+                'povray',
+                'omnetpp',
+                'astar',
+                'xalancbmk'
+            ],
 
-# Add the FORTRAN benchmark group.
-benchDict['FORTRAN'] = [
-    'bwaves',
-    'gamess',
-    'zeusmp',
-    'leslie',
-    'Gems',
-    'tonto'
-]
+            # Add the FORTRAN benchmark group.
+            'FORTRAN' : [
+                'bwaves',
+                'gamess',
+                'zeusmp',
+                'leslie',
+                'Gems',
+                'tonto'
+            ],
 
-# Add the MIXED language benchmark group.
-benchDict['MIXED'] = [
-    'gromacs',
-    'cactus',
-    'calculix',
-    'wrf'
-]
+            # Add the MIXED language benchmark group.
+            'MIXED' : [
+                'gromacs',
+                'cactus',
+                'calculix',
+                'wrf'
+            ],
 
-# The FP benchmarks without FORTRAN. (ie no dragonegg)
-benchDict['FP_NO_F'] = list(set(benchDict['FP']) - set(benchDict['FORTRAN'] + benchDict['MIXED']))
-#List of log files
-logFile = {}
+            # The FP benchmarks without FORTRAN. (ie no dragonegg/flang)
+            'FP_NO_F' : [
+                'milc',
+                'namd',
+                'dealII',
+                'soplex',
+                'povray',
+                'lbm',
+                'sphinx'
+            ]
+        }
+    },
 
-#Add all log files
-logFile['ALL'] = [
-        'adpcm',
-        'epic',
-        'g721',
-        'gsm',
-        'jpeg',
-        'pegwit'
-]
+    'CPU2017' : {
+        'BUILD_COMMAND' : 'runcpu --tune=base --config=%s -a build %s',
+        'SCRUB_COMMAND' : 'runcpu --tune=base --config=%s -a scrub %s',
+        'benchDict' : {
+            # Add all benchmarks individually.
+            '500.perlbench_r' : ['500.perlbench_r'],
+            '502.gcc_r' : ['502.gcc_r'],
+            '503.bwaves_r' : ['503.bwaves_r'],
+            '505.mcf_r' : ['505.mcf_r'],
+            '507.cactuBSSN_r' : ['507.cactuBSSN_r'],
+            '508.namd_r' : ['508.namd_r'],
+            '510.parest_r' : ['510.parest_r'],
+            '511.povray_r' : ['511.povray_r'],
+            '519.lbm_r' : ['519.lbm_r'],
+            '520.omnetpp_r' : ['520.omnetpp_r'],
+            '523.xalancbmk_r' : ['523.xalancbmk_r'],
+            '525.x264_r' : ['525.x264_r'],
+            '531.deepsjeng_r' : ['531.deepsjeng_r'],
+            '541.leela_r' : ['541.leela_r'],
+            '548.exchange2_r' : ['548.exchange2_r'],
+            '557.xz_r' : ['557.xz_r'],
+            '600.perlbench_s' : ['600.perlbench_s'],
+            '602.gcc_s' : ['602.gcc_s'],
+            '603.bwaves_s' : ['603.bwaves_s'],
+            '605.mcf_s' : ['605.mcf_s'],
+            '607.cactuBSSN_s' : ['607.cactuBSSN_s'],
+            '619.lbm_s' : ['619.lbm_s'],
+            '620.omnetpp_s' : ['620.omnetpp_s'],
+            '621.wrf_s' : ['621.wrf_s'],
+            '623.xalancbmk_s' : ['623.xalancbmk_s'],
+            '627.cam4_s' : ['627.cam4_s'],
+            '625.x264_s' : ['625.x264_s'],
+            '628.pop2_s' : ['628.pop2_s'],
+            '631.deepsjeng_s' : ['631.deepsjeng_s'],
+            '638.imagick_s' : ['638.imagick_s'],
+            '641.leela_s' : ['641.leela_s'],
+            '644.nab_s' : ['644.nab_s'],
+            '648.exchange2_s' : ['648.exchange2_s'],
+            '649.fotonik3d_s' : ['649.fotonik3d_s'],
+            '654.roms_s' : ['654.roms_s'],
+            '657.xz_s' : ['657.xz_s'],
 
-#Add log files individually
-logFile['adpcm'] = ['adpcm']
-logFile['epic'] = ['epic']
-logFile['g721'] = ['g721']
-logFile['gsm'] = ['gsm']
-logFile['jpeg'] = ['jpeg']
-logFile['pegwit'] = ['pegwit']
+            # Add TEST benchmark group.
+            'TEST' : [
+                '603.bwaves_s',
+                '619.lbm_s',
+                '607.cactuBSSN_s'
+            ],
 
-BUILD_COMMAND = "runspec --loose -size=ref -iterations=1 -config=%s --tune=base -r 1 -I -a build %s"
-SCRUB_COMMAND = "runspec --loose -size=ref -iterations=1 -config=%s --tune=base -r 1 -I -a scrub %s"
+            # Add ALL benchmark group.
+            'ALL' : [
+                '500.perlbench_r',
+                '600.perlbench_s',
+                '502.gcc_r',
+                '602.gcc_s',
+                '505.mcf_r',
+                '605.mcf_s',
+                '520.omnetpp_r',
+                '620.omnetpp_s',
+                '523.xalancbmk_r',
+                '623.xalancbmk_s',
+                '525.x264_r',
+                '625.x264_s',
+                '531.deepsjeng_r',
+                '631.deepsjeng_s',
+                '541.leela_r',
+                '641.leela_s',
+                '548.exchange2_r',
+                '648.exchange2_s',
+                '557.xz_r',
+                '657.xz_s',
+                '503.bwaves_r',
+                '603.bwaves_s',
+                '507.cactuBSSN_r',
+                '607.cactuBSSN_s',
+                '508.namd_r',
+                '510.parest_r',
+                '511.povray_r',
+                '519.lbm_r',
+                '619.lbm_s',
+                '521.wrf_r',
+                '621.wrf_s',
+                '526.blender_r',
+                '527.cam4_r',
+                '627.cam4_s',
+                '628.pop2_s',
+                '538.imagick_r',
+                '638.imagick_s',
+                '544.nab_r',
+                '644.nab_s',
+                '549.fotonik3d_r',
+                '649.fotonik3d_s',
+                '554.roms_r',
+                '654.roms_s'
+            ],
+
+            # Add INT benchmark group.
+            'INT' : [
+                '500.perlbench_r',
+                '600.perlbench_s',
+                '502.gcc_r',
+                '602.gcc_s',
+                '505.mcf_r',
+                '605.mcf_s',
+                '520.omnetpp_r',
+                '620.omnetpp_s',
+                '523.xalancbmk_r',
+                '623.xalancbmk_s',
+                '525.x264_r',
+                '625.x264_s',
+                '531.deepsjeng_r',
+                '631.deepsjeng_s',
+                '541.leela_r',
+                '641.leela_s',
+                '548.exchange2_r',
+                '648.exchange2_s',
+                '557.xz_r',
+                '657.xz_s',
+            ],
+
+            #Add INT SPECrate
+            'INT_RATE' : [
+                '500.perlbench_r',
+                '502.gcc_r',
+                '505.mcf_r',
+                '520.omnetpp_r',
+                '523.xalancbmk_r',
+                '525.x264_r',
+                '531.deepsjeng_r',
+                '541.leela_r',
+                '548.exchange2_r',
+                '557.xz_r',
+            ],
+
+            #Add INT SPECspeed
+            'INT_SPEED' : [
+                '600.perlbench_s',
+                '602.gcc_s',
+                '605.mcf_s',
+                '620.omnetpp_s',
+                '623.xalancbmk_s',
+                '625.x264_s',
+                '631.deepsjeng_s',
+                '641.leela_s',
+                '648.exchange2_s',
+                '657.xz_s',
+            ],
+
+            # Add FP benchmark group.
+            'FP' : [
+                '503.bwaves_r',
+                '603.bwaves_s',
+                '507.cactuBSSN_r',
+                '607.cactuBSSN_s',
+                '508.namd_r',
+                '510.parest_r',
+                '511.povray_r',
+                '519.lbm_r',
+                '619.lbm_s',
+                '521.wrf_r',
+                '621.wrf_s',
+                '526.blender_r',
+                '527.cam4_r',
+                '627.cam4_s',
+                '628.pop2_s',
+                '538.imagick_r',
+                '638.imagick_s',
+                '544.nab_r',
+                '644.nab_s',
+                '549.fotonik3d_r',
+                '649.fotonik3d_s',
+                '554.roms_r',
+                '654.roms_s'
+            ],
+
+            # Add FP SPECrate
+            'FP_RATE' : [
+                '503.bwaves_r',
+                '507.cactuBSSN_r',
+                '508.namd_r',
+                '510.parest_r',
+                '511.povray_r',
+                '519.lbm_r',
+                '521.wrf_r',
+                '526.blender_r',
+                '527.cam4_r',
+                '538.imagick_r',
+                '544.nab_r',
+                '549.fotonik3d_r',
+                '554.roms_r',
+            ],
+
+            # Add FP SPECrate w/o the non-working wrf
+            'FP_RATE_NWRF' : [
+                '503.bwaves_r',
+                '507.cactuBSSN_r',
+                '508.namd_r',
+                '510.parest_r',
+                '511.povray_r',
+                '519.lbm_r',
+                '526.blender_r',
+                '527.cam4_r',
+                '538.imagick_r',
+                '544.nab_r',
+                '549.fotonik3d_r',
+                '554.roms_r',
+            ],
+
+            # Add FP SPECspeed
+            'FP_SPEED' : [
+                '603.bwaves_s',
+                '607.cactuBSSN_s',
+                '619.lbm_s',
+                '621.wrf_s',
+                '627.cam4_s',
+                '628.pop2_s',
+                '638.imagick_s',
+                '644.nab_s',
+                '649.fotonik3d_s',
+                '654.roms_s'
+            ],
+
+            # Add C benchmark group.
+            'C' : [
+                '500.perlbench_r',
+                '600.perlbench_s',
+                '502.gcc_r',
+                '602.gcc_s',
+                '505.mcf_r',
+                '605.mcf_s',
+                '525.x264_r',
+                '625.x264_s',
+                '557.xz_r',
+                '657.xz_s',
+                '519.lbm_r',
+                '619.lbm_s',
+                '538.imagick_r',
+                '638.imagick_s',
+                '544.nab_r',
+                '644.nab_s',
+            ],
+
+            # Add C++ benchmark group.
+            'C++' : [
+                '520.omnetpp_r',
+                '620.omnetpp_s',
+                '523.xalancbmk_r',
+                '623.xalancbmk_s',
+                '531.deepsjeng_r',
+                '631.deepsjeng_s',
+                '541.leela_r',
+                '641.leela_s',
+                '508.namd_r',
+                '510.parest_r',
+            ],
+
+            # Add the FORTRAN benchmark group.
+            'FORTRAN' : [
+                '548.exchange2_r',
+                '648.exchange2_s',
+                '503.bwaves_r',
+                '603.bwaves_s',
+                '549.fotonik3d_r',
+                '649.fotonik3d_s',
+                '554.roms_r',
+                '654.roms_s'
+            ],
+
+            # Add the MIXED language benchmark group.
+            'MIXED' : [
+                '507.cactuBSSN_r',
+                '607.cactuBSSN_s',
+                '511.povray_r',
+                '521.wrf_r',
+                '621.wrf_s',
+                '526.blender_r',
+                '527.cam4_r',
+                '627.cam4_s',
+                '628.pop2_s'
+            ],
+
+            # The FP benchmarks without FORTRAN. (ie no dragonegg/flang)
+            'FP_NO_F' : [
+                '508.namd_r',
+                '510.parest_r',
+                '511.povray_r',
+                '519.lbm_r',
+                '619.lbm_s',
+                '526.blender_r',
+                '538.imagick_r',
+                '638.imagick_s',
+                '544.nab_r',
+                '644.nab_s'
+            ]
+        }
+    }
+}
+
+
+DETECT_COMMAND = 'if ! . shrc &> /dev/null; then  echo "NX_INSTALL";  elif runspec -h &> /dev/null; then echo "CPU2006"; elif runcpu -h &> /dev/null; then echo "CPU2017"; else echo "SPEC_AUTODETECT_ERROR"; fi'
 LOG_DIR = 'logs/'
 
 # Regular expressions.
@@ -266,6 +558,8 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
             totalTimedOutImproved = 0
             totalTimedOutNotImproved = 0
             totalCost = 0
+            totalAcoImprovement = 0
+            totalAcoPostImprovement = 0
             totalImprovement = 0
             totalOptSchedSpills = 0
             totalEnumeratedSizes = 0
@@ -294,7 +588,10 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                 optimalNotImproved = 0
                 timedOutImproved = 0
                 timedOutNotImproved = 0
-                cost = improvement = 0
+                cost = 0
+                acoImprovement = 0
+                acoPostImprovement = 0
+                improvement = 0
                 optSchedSpills = 0
                 enumeratedSizes = 0
                 optimalImprovedSizes = 0
@@ -313,6 +610,8 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                     if block['success']:
                         successful += 1
                         cost += block['listCost']
+                        acoImprovement += block['acoImprovement']
+                        acoPostImprovement += block['acoPostImprovement']
                         size = block['size']
                         spills = block['optSchedSpills']
                         sizesList.append(size)
@@ -390,10 +689,15 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                                   (timedOutNotImproved, (100 * timedOutNotImproved / enumerated) if enumerated else 0, nonOptimalNotImprovedStr))
                 blocks_file.write('  Heuristic cost: %d\n' %
                                   cost)
+                blocks_file.write('  Aco cost: %d\n' %
+                                  (cost - acoImprovement))
                 blocks_file.write('  B&B cost: %d\n' %
-                                  (cost - improvement))
+                                  (cost - acoImprovement - improvement))
+                fullImprovement = acoImprovement + improvement + acoPostImprovement
+                blocks_file.write('  AcoPost cost: %d\n' %
+                                  (cost - fullImprovement))
                 blocks_file.write('  Cost improvement: %d (%.2f%%)\n' %
-                                  (improvement, (100 * improvement / cost) if cost else 0))
+                                  (fullImprovement, (100 * fullImprovement / cost) if cost else 0))
                 if trackOptSchedSpills:
                     blocks_file.write('  Simulated Block Spills: %d\n' %
                                     optSchedSpills)
@@ -406,6 +710,8 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                 totalTimedOutImproved += timedOutImproved
                 totalTimedOutNotImproved += timedOutNotImproved
                 totalCost += cost
+                totalAcoImprovement += acoImprovement
+                totalAcoPostImprovement += acoPostImprovement
                 totalImprovement += improvement
                 totalOptSchedSpills += optSchedSpills
                 totalEnumeratedSizes += enumeratedSizes
@@ -425,7 +731,7 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
             totalOptimalNotImprovedStr = ''
             totalNonOptimalImprovedStr = ''
             totalNonOptimalNotImprovedStr = ''
-            if trackOptSchedSpills and enumerated > 0:
+            if trackOptSchedSpills and totalEnumerated > 0:
                 try:
                     totalEnumeratedStr += '  {:,} instrs, {:,} spills'.format(totalEnumeratedSizes, totalEnumeratedSpills)
 
@@ -462,10 +768,15 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                               (totalTimedOutNotImproved, (100 * totalTimedOutNotImproved / totalEnumerated) if totalEnumerated else 0, totalNonOptimalNotImprovedStr))
             blocks_file.write('  Heuristic cost: %d\n' %
                               totalCost)
+            blocks_file.write('  Aco cost: %d\n' %
+                              (totalCost - totalAcoImprovement))
             blocks_file.write('  B&B cost: %d\n' %
-                              (totalCost - totalImprovement))
+                              (totalCost - totalAcoImprovement - totalImprovement))
+            totalFullImprovement = totalAcoImprovement + totalImprovement + totalAcoPostImprovement
+            blocks_file.write('  AcoPost cost: %d\n' %
+                              (totalCost -totalFullImprovement))
             blocks_file.write('  Cost improvement: %d (%.2f%%)\n' %
-                              (totalImprovement, (100 * totalImprovement / totalCost) if totalCost else 0))
+                              (totalFullImprovement, (100 * totalFullImprovement / totalCost) if totalCost else 0))
             if trackOptSchedSpills:
                 blocks_file.write('  Total Simulated Block Spills: %d\n' %
                                 totalOptSchedSpills)
@@ -491,7 +802,7 @@ def writeStats(stats, spills, weighted, times, blocks, trackOptSchedSpills):
                               ((sum(optimalTimesList) / len(optimalTimesList)) if optimalTimesList else 0))
 
 
-def calculateBlockStats(output, trackOptSchedSpills):
+def calculateBlockStats(output, trackOptSchedSpills, normalized):
     blocks = split_blocks(output)
     stats = []
     for index, block in enumerate(blocks):
@@ -518,7 +829,7 @@ def calculateBlockStats(output, trackOptSchedSpills):
                 else:
                     optSchedSpills = 0
 
-                costLowerBound = events['CostLowerBound']['cost']
+                costLowerBound = events['CostLowerBound']['cost'] if not normalized else 0
                 listCost = costLowerBound + events['HeuristicResult']['cost']
                 # The block is not enumerated if the list schedule is optimal or there is a zero
                 # time limit for enumeration.
@@ -543,6 +854,15 @@ def calculateBlockStats(output, trackOptSchedSpills):
                     isOptimal = False
                     improvement = 0
 
+            if 'ACO_sched_complete' in events:
+                acoImprovement = events['AcoSchedComplete']['improvement']
+            else:
+                acoImprovement = 0
+            if 'ACOpost_sched_complete' in events:
+                acoPostImprovement = events['AcoPostSchedComplete']['improvement']
+            else:
+                acoPostImprovement = 0
+
             stats.append({
                 'name': name,
                 'size': int(size),
@@ -552,9 +872,12 @@ def calculateBlockStats(output, trackOptSchedSpills):
                 'isOptimal': isOptimal,
                 'listCost': listCost,
                 'improvement': improvement,
+                'acoImprovement': acoImprovement,
+                'acoPostImprovement': acoPostImprovement,
                 'optSchedSpills': optSchedSpills
             })
-        except:
+        except Exception as e:
+            print e
             print '  WARNING: Could not parse block #%d:' % (index + 1)
             print "Unexpected error:", sys.exc_info()[0]
             for line in blocks[index].split('\n')[1:-1][:10]:
@@ -607,17 +930,39 @@ Defining this function makes it easier to parse files.
 """
 
 
-def getBenchmarkResult(output, trackOptSchedSpills):
+def getBenchmarkResult(output, trackOptSchedSpills, normalized):
     # Handle parsing log files that were not generated by runspec and have no time information.
     time = int(TIMES_REGEX.findall(output)[1]) if len(TIMES_REGEX.findall(output)) > 0 else -1
     return {
         'time': time,
         'spills': calculateSpills(output),
-        'blocks': calculateBlockStats(output, trackOptSchedSpills),
+        'blocks': calculateBlockStats(output, trackOptSchedSpills, normalized),
     }
 
+def detectSPECInstall():
+    try:
+        p = subprocess.Popen(['/bin/bash', '-c', DETECT_COMMAND], stdout=subprocess.PIPE)
+        output = p.stdout.read().strip()
+    except subprocess.CalledProcessError as e:
+        print "FATAL ERROR in runspec wrapper.  Could not auto detect SPEC installation"
+        sys.exit()
 
-def runBenchmarks(benchmarks, testOutDir, shouldWriteLogs, config, trackOptSchedSpills):
+    if output == "SPEC_AUTODETECT_ERROR":
+        print "Runspec-wrapper found the shrc script, but was unable to find either runspec or runcpu"
+        sys.exit()
+
+    if output == "NX_INSTALL":
+        print "SPEC does not appear to be installed in this directory"
+        sys.exit()
+
+    return output
+
+def runBenchmarks(benchmarks, testOutDir, shouldWriteLogs, config, trackOptSchedSpills, normalized):
+    # Detect Install
+    version = detectSPECInstall()
+    BUILD_COMMAND = specVersions[version]['BUILD_COMMAND']
+    SCRUB_COMMAND = specVersions[version]['SCRUB_COMMAND']
+
     results = {}
     for bench in benchmarks:
         print 'Running', bench
@@ -633,7 +978,7 @@ def runBenchmarks(benchmarks, testOutDir, shouldWriteLogs, config, trackOptSched
         except subprocess.CalledProcessError as e:
             print '  WARNING: Benchmark command failed: %s.' % e
         else:
-            results[bench] = getBenchmarkResult(output, trackOptSchedSpills)
+            results[bench] = getBenchmarkResult(output, trackOptSchedSpills, normalized)
 
             # Optionally write log files to results directory.
             if shouldWriteLogs is True:
@@ -650,48 +995,45 @@ def writeLogs(output, testOutDir, bench):
 
 
 def main(args):
-    ## Select benchmarks.
-    benchArgs = args.bench.split(',')
-    # List of benchmarks to run.
-    benchmarks = []
-    for benchArg in benchArgs:
-        if benchArg not in benchDict:
-            print 'Fatal: Unknown benchmark specified: "%s".' % benchArg
-            if benchArg == 'all':
-                print 'Did you mean ALL?'
-            sys.exit(1)
-
-        benchmarks = list(set(benchmarks + benchDict[benchArg]))
-
     # Parse a log file or multiple log files instead of running benchmark
     results = {}
     if args.logfile is not None:
-        logArgs = args.logfile.split(',')
-        logfiles = []
-        for logArg in logArgs:
-            if logArg not in logFile:
-                print 'Fatal: Unknown log file specified: "%s".' % logArg
-                if logArg == 'all':
-                    print 'Did you mean ALL?'
-                sys.exit(1)
-
-            logfiles = list(set(logfiles + logFile[logArg]))
+        logfiles = [f for f in os.listdir(args.logfile) if os.path.isfile(os.path.join(args.logfile, f)) and f[-4:]=='.log']
 
         for log in logfiles:
-            with open('./' + log + '/' + log + '.log') as log_file:
+            with open(os.path.join(args.logfile, f)) as log_file:
                 output = log_file.read()
-                results[log] = getBenchmarkResult(output, args.trackOptSchedSpills)
+                results[log] = getBenchmarkResult(output, args.trackOptSchedSpills, args.normalized)
 
-            spills = os.path.join(args.outdir, args.spills)
-            weighted = os.path.join(args.outdir, args.weighted)
-            times = os.path.join(args.outdir, args.times)
-            blocks = os.path.join(args.outdir, args.blocks)
+                spills = os.path.join(args.outdir, args.spills)
+                weighted = os.path.join(args.outdir, args.weighted)
+                times = os.path.join(args.outdir, args.times)
+                blocks = os.path.join(args.outdir, args.blocks)
 
-            # Write out the results from the logfile.
-            writeStats(results, spills, weighted, times, blocks, args.trackOptSchedSpills)
+                # Write out the results from the logfile.
+                writeStats(results, spills, weighted, times, blocks, args.trackOptSchedSpills)
 
         # Run the benchmarks and collect results.
     else:
+
+        # Detect Install
+        version = detectSPECInstall()
+        benchDict = specVersions[version]['benchDict']
+        print 'Using benchmark suite: "%s".' % version
+
+        ## Select benchmarks.
+        benchArgs = args.bench.split(',')
+        # List of benchmarks to run.
+        benchmarks = []
+        for benchArg in benchArgs:
+            if benchArg not in benchDict:
+                print 'Fatal: Unknown benchmark specified: "%s".' % benchArg
+                if benchArg == 'all':
+                    print 'Did you mean ALL?'
+                sys.exit(1)
+
+            benchmarks = list(set(benchmarks + benchDict[benchArg]))
+
         # Create a directory for the test results.
         if not os.path.exists(args.outdir):
             os.makedirs(args.outdir)
@@ -728,8 +1070,7 @@ def main(args):
                     os.makedirs(os.path.join(testOutDir, LOG_DIR))
 
             # Run the benchmarks
-            results = runBenchmarks(benchmarks, testOutDir, args.writelogs, args.config, args.trackOptSchedSpills)
-
+            results = runBenchmarks(benchmarks, testOutDir, args.writelogs, args.config, args.trackOptSchedSpills, args.normalized)
 
             spills = os.path.join(testOutDir, args.spills)
             weighted = os.path.join(testOutDir, args.weighted)
@@ -796,5 +1137,10 @@ if __name__ == '__main__':
                       dest="trackOptSchedSpills",
                       default=True,
                       help='Should the simulated number of spills per-block be tracked (%default).')
+    parser.add_option('-n', '--normalized',
+                      action="store_true",
+                      dest="normalized",
+                      default=False,
+                      help='Output normalized/relative costs to blocks.dat instead of absolute costs (%default).')
 
     main(parser.parse_args()[0])


### PR DESCRIPTION
In an effort to align the logic of our algorithm more closely with the algorithm defined in our papers, this PR implements three main things:

1. Instead of using a cost function that is weighted between schedLength and RP, we make our decisions based on either the "raw" value of schedLength or RP or both (both meaning multiple conditional statements rather than a value that combines both sources into one).
2. We stop exploring the tree in the second pass after we have found a schedule that corresponds with the first pass' value of spillCostFUunc
3. If, after introducing latency information to the instructions, the max latency is 1, we skip the second pass as it will just be an extension of the first pass.

The functions where we make use of weighted cost function are, UpdtOptmlSchedule, ChkCostFsblty, WasObjctvMet, and ChkCostDomntn. These have been split up into functions for frstPss, scndPss, and wghtd to implement pass specific code. This was done to enhance code clarity.

Finally, appendAndCheckSuffixes makes use of the weighted cost function, however, it seems this feature is no longer used / needs to be maintained. As a result, this PR does not attempt to remove the weighted cost from this function, and, in fact, this code ensures appendAndCheckSuffixes does not work with the two-pass algorithm. That said, I have continued to maintain the weightedCost value in our two-pass algorithm, so reactivating appendAndCheckSuffixes for the two-pass algorithm will be a simple manner of using the pass-dependent methods to get the weightedCost and invoking the unchanged logic of appendAndCheckSuffixes which makes use of the weighted cost.