### PR TITLE
Fix missing LLVM GPG key

### DIFF
--- a/.github/workflows/clangtidy.yml
+++ b/.github/workflows/clangtidy.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup LLVM GPG key
+      run: |
+        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+
     - name: Install clang-tidy
       run: |
         sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main"


### PR DESCRIPTION
The clang-tidy check uses apt-get to install LLVM components. This adds the missing GPG key.