### PR TITLE
Add ArrayRef2D<T> for a 2D view of a single array

### DIFF
--- a/include/opt-sched/Scheduler/array_ref2d.h
+++ b/include/opt-sched/Scheduler/array_ref2d.h
@@ -1,0 +1,105 @@
+#ifndef OPTSCHED_ARRAY_REF_2D_H
+#define OPTSCHED_ARRAY_REF_2D_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include <cassert>
+#include <cstddef>
+
+namespace llvm {
+namespace opt_sched {
+
+/**
+ * \brief Provides a 2D view over a single allocation
+ *
+ * \details 2D arrays are best implemented by using a single allocation, then
+ * computing the index into this single allocation based on the 2D location we
+ * are trying to access. This type abstracts away that work, doing it for you.
+ *
+ * \see MutableArrayRef2D
+ */
+template <typename T> class ArrayRef2D {
+public:
+  /**
+   * \brief Constructs an ArrayRef2D with the specified dimensions.
+   * \param Ref     Must have a size precisely Rows * Columns.
+   * \param Rows    The number of rows in this 2D matrix.
+   * \param Columns The number of columns in this 2D matrix.
+   */
+  explicit ArrayRef2D(llvm::ArrayRef<T> Ref, size_t Rows, size_t Columns)
+      : Ref(Ref), Rows(Rows), Columns(Columns) {
+    assert(Rows * Columns == Ref.size());
+  }
+
+  size_t rows() const { return Rows; }
+  size_t columns() const { return Columns; }
+
+  /**
+   * \brief Access an element at the specified row and columns. `[{row, col}]`
+   * \detail
+   * A C-style array `int arr[10][20]` is a single contiguous block of memory.
+   * It would be accessed as `arr[row][col]`.
+   * For ArrayRef2D, a single block of memory such as
+   * `int* arr = new int[10 * 20]` is accessed as `ref[{row, col}]`.
+   *
+   * If you want to do x, y indexing, prefer `ref[{y, x}]` over `ref[{x, y}]`.
+   * When accessed in this way, consecutive x values are placed together in
+   * memory, which is usually what is expected.
+   */
+  const T &operator[](size_t(&&RowCol)[2]) const {
+    return Ref[computeIndex(RowCol[0], RowCol[1], Rows, Columns)];
+  }
+
+  /**
+   * \brief Recovers the underlying ArrayRef.
+   */
+  llvm::ArrayRef<T> underlyingData() const { return Ref; }
+
+private:
+  llvm::ArrayRef<T> Ref;
+  size_t Rows;
+  size_t Columns;
+
+  static size_t computeIndex(size_t row, size_t col, size_t Rows,
+                             size_t Columns) {
+    assert(row < Rows && "Invalid row");
+    assert(col < Columns && "Invalid column");
+    size_t index = row * Columns + col;
+    assert(index < Rows * Columns); // Should be redundant with prior asserts.
+    return index;
+  }
+};
+
+/**
+ * \brief An ArrayRef2D which allows mutation.
+ * \note Inherits from ArrayRef2D, allowing slicing from this type to
+ * ArrayRef2D in the same manner as LLVM's ArrayRef and MutableArrayRef
+ *
+ * \see ArrayRef2D
+ */
+template <typename T> class MutableArrayRef2D : public ArrayRef2D<T> {
+public:
+  explicit MutableArrayRef2D(llvm::MutableArrayRef<T> Ref, size_t Rows,
+                             size_t Columns)
+      : ArrayRef2D<T>(Ref, Rows, Columns) {}
+
+  /**
+   * \brief Access an element at the specified row and columns. `[{row, col}]`
+   * \returns a _mutable_ reference to the element at the specified location.
+   */
+  T &operator[](size_t(&&RowCol)[2]) const {
+    ArrayRef2D<T> cref = *this;
+    return const_cast<T &>(cref[{RowCol[0], RowCol[1]}]);
+  }
+
+  /**
+   * \brief Recovers the underlying MutableArrayRef.
+   */
+  llvm::MutableArrayRef<T> underlyingData() const {
+    return static_cast<const llvm::MutableArrayRef<T> &>(
+        ArrayRef2D<T>::underlyingData());
+  }
+};
+} // namespace opt_sched
+} // namespace llvm
+
+#endif

--- a/unittests/Basic/ArrayRef2DTest.cpp
+++ b/unittests/Basic/ArrayRef2DTest.cpp
@@ -1,0 +1,131 @@
+#include "opt-sched/Scheduler/array_ref2d.h"
+
+#include <array>
+
+#include "gtest/gtest.h"
+
+using namespace llvm::opt_sched;
+
+namespace {
+TEST(ArrayRef2D, CanAccessElements) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  EXPECT_EQ(1, (Ref[{0, 0}]));
+  EXPECT_EQ(2, (Ref[{0, 1}]));
+  EXPECT_EQ(3, (Ref[{0, 2}]));
+  EXPECT_EQ(4, (Ref[{1, 0}]));
+  EXPECT_EQ(5, (Ref[{1, 1}]));
+  EXPECT_EQ(6, (Ref[{1, 2}]));
+}
+
+TEST(ArrayRef2D, CanGetRowsAndColumns) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  EXPECT_EQ(2, Ref.rows());
+  EXPECT_EQ(3, Ref.columns());
+}
+
+TEST(ArrayRef2D, AccessReturnsReferenceToElements) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  EXPECT_EQ(&Arr[0], &(Ref[{0, 0}]));
+}
+
+TEST(ArrayRef2D, AccessDoesNotAllowChanges) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  static_assert(std::is_same<const int &, decltype(Ref[{0, 0}])>::value, "");
+}
+
+TEST(ArrayRef2D, RequiresRectangle) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5,
+  };
+
+  EXPECT_DEBUG_DEATH(ArrayRef2D<int>(Arr, 2, 3), ".*");
+}
+
+TEST(ArrayRef2D, AccessingFailsForOutOfBounds) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  EXPECT_DEBUG_DEATH((Ref[{5, 10}]), ".*");
+}
+
+TEST(ArrayRef2D, WorksForEmpty) {
+  std::array<int, 0> Arr{};
+
+  ArrayRef2D<int> Ref(Arr, 0, 0);
+  EXPECT_EQ(0u, Ref.rows());
+  EXPECT_EQ(0u, Ref.columns());
+  EXPECT_EQ(0u, Ref.underlyingData().size());
+}
+
+TEST(ArrayRef2D, AccessingEmptyRefFails) {
+  std::array<int, 0> Arr{};
+
+  ArrayRef2D<int> Ref(Arr, 0, 0);
+  EXPECT_DEBUG_DEATH((Ref[{0, 0}]), ".*");
+}
+
+TEST(ArrayRef2D, UnderlyingDataIsArrayRef) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  ArrayRef2D<int> Ref(Arr, 2, 3);
+  static_assert(
+      std::is_same<llvm::ArrayRef<int>, decltype(Ref.underlyingData())>::value,
+      "");
+}
+
+TEST(MutableArrayRef2D, IsConvertibleToArrayRef2D) {
+  static_assert(
+      std::is_convertible<MutableArrayRef2D<int>, ArrayRef2D<int>>::value, "");
+}
+
+TEST(MutableArrayRef2D, UnderlyingDataIsMutableArrayRef) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  MutableArrayRef2D<int> Ref(Arr, 2, 3);
+  static_assert(std::is_same<llvm::MutableArrayRef<int>,
+                             decltype(Ref.underlyingData())>::value,
+                "");
+}
+
+TEST(MutableArrayRef2D, CanMutateViaAccess) {
+  int Arr[] = {
+      1, 2, 3, //
+      4, 5, 6,
+  };
+
+  MutableArrayRef2D<int> Ref(Arr, 2, 3);
+  Ref[{1, 1}] = -5;
+  EXPECT_EQ(-5, (Ref[{1, 1}]));
+  EXPECT_EQ(-5, Arr[4]);
+}
+} // namespace

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_optsched_unittest(OptSchedBasicTests
+  ArrayRef2DTest.cpp
   ConfigTest.cpp
   LinkedListTest.cpp
   LoggerTest.cpp


### PR DESCRIPTION
When working with a 2D array/matrix from a single allocation,
ArrayRef2D<T> and MutableArrayRef2D<T> provides a simpler way to access
a 2D location in this matrix.

----

Added Paul as a reviewer because I saw some 2d table accessing in the ACO implementation.