### PR TITLE
Add a debug option to dump DDGs

### DIFF
--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -249,3 +249,10 @@ TREAT_ORDER_DEPS_AS_DATA_DEPS NO
 
 # The number of bits in the hash table used in history-based domination.
 HIST_TABLE_HASH_BITS 16
+
+# Whether to dump the DDG for all the regions we schedule.
+# This is a debugging option.
+DUMP_DDGS NO
+
+# Where to dump the DDGs.
+# DDG_DUMP_PATH ~/ddgs

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -249,3 +249,10 @@ TREAT_ORDER_DEPS_AS_DATA_DEPS NO
 
 # The number of bits in the hash table used in history-based domination.
 HIST_TABLE_HASH_BITS 16
+
+# Whether to dump the DDG for all the regions we schedule.
+# This is a debugging option.
+DUMP_DDGS NO
+
+# Where to dump the DDGs
+# DDG_DUMP_PATH ~/ddgs

--- a/include/opt-sched/Scheduler/graph_trans.h
+++ b/include/opt-sched/Scheduler/graph_trans.h
@@ -25,6 +25,8 @@ public:
   GraphTrans(DataDepGraph *dataDepGraph);
   virtual ~GraphTrans(){};
 
+  virtual const char *Name() const = 0;
+
   // Apply the graph transformation to the DataDepGraph.
   virtual FUNC_RESULT ApplyTrans() = 0;
 
@@ -81,6 +83,8 @@ inline void GraphTrans::SetNumNodesInGraph(InstCount numNodesInGraph) {
 class StaticNodeSupTrans : public GraphTrans {
 public:
   StaticNodeSupTrans(DataDepGraph *dataDepGraph, bool IsMultiPass);
+
+  const char *Name() const override { return "rp.nodesup"; }
 
   FUNC_RESULT ApplyTrans() override;
 

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -119,6 +119,11 @@ private:
   // Whether to verify the schedule after calculating it.
   bool vrfySched_;
 
+  // Whether to dump the DDGs for the blocks we schedule
+  bool DumpDDGs_;
+  // Where to dump the DDGs
+  std::string DDGDumpPath_;
+
   // The normal heuristic scheduling results.
   InstCount hurstcCost_;
 

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -236,6 +236,10 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
   for (auto &GT : *GraphTransformations) {
     rslt = GT->ApplyTrans();
 
+    if (DumpDDGs_) {
+      dumpDDG(dataDepGraph_, DDGDumpPath_, GT->Name());
+    }
+
     if (rslt != RES_SUCCESS)
       return rslt;
 
@@ -244,10 +248,6 @@ FUNC_RESULT SchedRegion::FindOptimalSchedule(
     if (rslt != RES_SUCCESS) {
       Logger::Info("Invalid DAG after graph transformations");
       return rslt;
-    }
-
-    if (DumpDDGs_) {
-      dumpDDG(dataDepGraph_, DDGDumpPath_, GT->Name());
     }
   }
 

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -48,7 +48,7 @@ static std::string ComputeDDGDumpPath() {
     llvm::SmallString<32> FixedPath;
     const std::error_code ec =
         fs::real_path(Path, FixedPath, /* expand_tilde = */ true);
-    if (!ec)
+    if (ec)
       llvm::report_fatal_error(
           "Unable to expand DDG_DUMP_PATH. " + ec.message(), false);
     Path.assign(FixedPath.begin(), FixedPath.end());

--- a/unittests/Basic/ConfigTest.cpp
+++ b/unittests/Basic/ConfigTest.cpp
@@ -19,6 +19,16 @@ TEST(Config, ReadString) {
   EXPECT_EQ("VALUE", config.GetString("KEY"));
 }
 
+TEST(Config, ReadStringPath) {
+  Config config;
+  std::istringstream input(R"(
+        KEY some/path/
+    )");
+  config.Load(input);
+
+  EXPECT_EQ("some/path/", config.GetString("KEY"));
+}
+
 TEST(Config, ReadInt) {
   Config config;
   std::istringstream input(R"(


### PR DESCRIPTION
Dumps the DDG of every block we schedule to the specified location.
To control which DDGs are dumped, configure the scheduler to only
schedule the blocks of interest.

-----

I've found that I often want to look at a block's DDG when debugging. This provides a mechanism to dump the DDGs. I also write out the DDGs after any graph transformations so that we can see the effect of the graph transformations.

I do not currently have an option to "only write out these particular DDGs". Instead, if I want to do that, I constrain the scheduler to only schedule the blocks whose DDGs I want (SCHEDULE_SPECIFIC_REGIONS works well).