### PR TITLE
Fixed bug in unit tests(use of invalid pointer)

### DIFF
--- a/unittests/Basic/LinkedListTest.cpp
+++ b/unittests/Basic/LinkedListTest.cpp
@@ -276,8 +276,8 @@ TEST(LinkedListFixed, CanAddToMaxCapacityAfterRemove) {
   numbers.erase(numIt);
 
   while (list.GetElmntCnt() < 20) {
-    list.InsrtElmnt(&numbers[3]);
-    numbers.push_back(numbers[3]);
+    list.InsrtElmnt(&numbers2[3]);
+    numbers.push_back(numbers2[3]);
   }
 
   ASSERT_EQ(numbers.size(), list.GetElmntCnt());


### PR DESCRIPTION
There was a bug in the LL unit tests.  Pointers to elements in `numbers`  were being inserted into the linked list, while elements were also being added to numbers.  This is undefined behavior since adding or removing elements from of a vector invalidates all pointers to elements of the vector.

The test failures occurred after a sufficient number of elements were added to 'numbers' to cause its data to be relocated(on my machine and on GitHub this was 2).  The pointers previously stored in `list` were not updated, and pointed to memory that was subsequently overwritten.  When the `list`'s values were checked against the `numbers`'s values failure occurred.