### PR TITLE
Add mode to ddg2dot.py to make differences in edges apparent

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,2 @@
+[pycodestyle]
+max_line_length = 120

--- a/util/misc/ddg2dot.py
+++ b/util/misc/ddg2dot.py
@@ -3,14 +3,10 @@ import argparse
 import sys
 import re
 
-parser = argparse.ArgumentParser(
-    description='Convert data_dep WriteToFile format to a .dot file')
-parser.add_argument(
-    'input', help='The WriteToFile format file to convert. Input a single hyphen (-) to read from stdin')
-parser.add_argument(
-    '-o', '--output', help='The destination to write to. Defaults to stdout')
-parser.add_argument('--filter-weights', nargs='*', default=[],
-                    help='filter out weights with the respective values')
+parser = argparse.ArgumentParser(description='Convert data_dep WriteToFile format to a .dot file')
+parser.add_argument('input', help='The WriteToFile format file to convert. Input a single hyphen (-) to read from stdin')
+parser.add_argument('-o', '--output', help='The destination to write to. Defaults to stdout')
+parser.add_argument('--filter-weights', nargs='*', default=[], help='filter out weights with the respective values')
 parser.add_argument(
     '--base', help='Consider the edges from this other .ddg when layouting. Those edges will be made invisible.')
 
@@ -32,10 +28,8 @@ if args.base:
 else:
     basetext = ''
 
-NODE_RE = re.compile(
-    r'node (?P<number>\d+) "(?P<name>.*?)"(\s*"(?P<other_name>.*?)")?')
-EDGE_RE = re.compile(
-    r'dep (?P<from>\d+) (?P<to>\d+) "(?P<type>.*?)" (?P<weight>\d+)')
+NODE_RE = re.compile(r'node (?P<number>\d+) "(?P<name>.*?)"(\s*"(?P<other_name>.*?)")?')
+EDGE_RE = re.compile(r'dep (?P<from>\d+) (?P<to>\d+) "(?P<type>.*?)" (?P<weight>\d+)')
 
 # Holds the resulting strings as a list of the lines.
 result = ['digraph G {\n']
@@ -107,8 +101,10 @@ for match in EDGE_RE.finditer(basetext):
 # Graph is now finished:
 result.append('}\n')
 
-output = sys.stdout
-if args.output:
-    output = open(args.output, 'w')
+filecontents = ''.join(result)
 
-print(''.join(result), file=output)
+if args.output:
+    with open(args.output, 'w') as f:
+        print(filecontents, file=f)
+else:
+    print(filecontents)

--- a/util/misc/ddg2dot.py
+++ b/util/misc/ddg2dot.py
@@ -3,10 +3,16 @@ import argparse
 import sys
 import re
 
-parser = argparse.ArgumentParser(description='Convert data_dep WriteToFile format to a .dot file')
-parser.add_argument('input', help='The WriteToFile format file to convert. Input a single hyphen (-) to read from stdin')
-parser.add_argument('-o', '--output', help='The destination to write to. Defaults to stdout')
-parser.add_argument('--filter-weights', nargs='*', default=[], help='filter out weights with the respective values')
+parser = argparse.ArgumentParser(
+    description='Convert data_dep WriteToFile format to a .dot file')
+parser.add_argument(
+    'input', help='The WriteToFile format file to convert. Input a single hyphen (-) to read from stdin')
+parser.add_argument(
+    '-o', '--output', help='The destination to write to. Defaults to stdout')
+parser.add_argument('--filter-weights', nargs='*', default=[],
+                    help='filter out weights with the respective values')
+parser.add_argument(
+    '--base', help='Consider the edges from this other .ddg when layouting. Those edges will be made invisible.')
 
 args = parser.parse_args()
 
@@ -20,8 +26,16 @@ filtered_weights = set(int(x) for x in args.filter_weights)
 text = infile.read()
 infile.close()
 
-NODE_RE = re.compile(r'node (?P<number>\d+) "(?P<name>.*?)"(\s*"(?P<other_name>.*?)")?')
-EDGE_RE = re.compile(r'dep (?P<from>\d+) (?P<to>\d+) "(?P<type>.*?)" (?P<weight>\d+)')
+if args.base:
+    with open(args.base) as f:
+        basetext = f.read()
+else:
+    basetext = ''
+
+NODE_RE = re.compile(
+    r'node (?P<number>\d+) "(?P<name>.*?)"(\s*"(?P<other_name>.*?)")?')
+EDGE_RE = re.compile(
+    r'dep (?P<from>\d+) (?P<to>\d+) "(?P<type>.*?)" (?P<weight>\d+)')
 
 # Holds the resulting strings as a list of the lines.
 result = ['digraph G {\n']
@@ -30,13 +44,35 @@ result = ['digraph G {\n']
 for match in NODE_RE.finditer(text):
     num = match['number']
     name = match['name']
-    if name == 'artificial': # Prettify entry/exit names
+    if name == 'artificial':  # Prettify entry/exit names
         name = ['exit', 'entry'][match['other_name'] == '__optsched_entry']
 
     # Add the node to the graph. Include a node to make it clear what this is
     result.append(f'    n{num} [label="{name}:n{num}"];\n')
 
 result.append('\n')
+
+
+def create_edge_attrs(**attrs):
+    if not attrs:
+        return ''
+    attrtext = ' '.join(f'{key}="{value}"' for key, value in attrs.items())
+    return f' [{attrtext}]'
+
+
+def create_label(filtered_weights, weight, type_):
+    # The additional label text if we want to display the weight
+    # (that is, if the weight is not filtered out)
+    weight_label = '' if int(weight) in filtered_weights else ':' + weight
+    # The actual label text
+    return weight_label if type_ == 'data' else f'{type_}{weight_label}'
+
+
+def create_edge(from_, to, **attrs):
+    return f'    n{from_} -> n{to}{create_edge_attrs(**attrs)};\n'
+
+
+edges = set()
 
 # Create the edges in the graph
 for match in EDGE_RE.finditer(text):
@@ -45,22 +81,34 @@ for match in EDGE_RE.finditer(text):
     type_ = match['type']
     weight = match['weight']
 
-    # The additional label text if we want to display the weight
-    # (that is, if the weight is not filtered out)
-    weight_label = '' if int(weight) in filtered_weights else ':' + weight
-    # The actual label text
-    label = weight_label if type_ == 'data' else f'{type_}{weight_label}'
-    # The dot syntax to produce the actual label
-    label_section = f'label="{label}"'
+    result.append(
+        create_edge(
+            from_, to,
+            label=create_label(filtered_weights, weight, type_),
+        )
+    )
+    edges.add((from_, to))
 
-    attr_section = f' [{label_section}]' if label else ''
-    # Add the edge
-    result.append(f'    n{from_} -> n{to}{attr_section};\n')
+for match in EDGE_RE.finditer(basetext):
+    from_ = match['from']
+    to = match['to']
+    type_ = match['type']
+    weight = match['weight']
+
+    if (from_, to) not in edges:
+        result.append(
+            create_edge(
+                from_, to,
+                label=create_label(filtered_weights, weight, type_),
+                style="invis",
+            )
+        )
 
 # Graph is now finished:
 result.append('}\n')
 
 output = sys.stdout
-if args.output: output = open(args.output, 'w')
+if args.output:
+    output = open(args.output, 'w')
 
 print(''.join(result), file=output)


### PR DESCRIPTION
When edges are added or removed via graph transformations, comparing the
DDGs via ddg2dot.py would be rather difficult. This augments ddg2dot.py
to add invisible edges to encourage `dot` to produce the graphs in the
same layout, with just the visibility of the edges being different.

<details>
<summary>Example graphs augmented with this new feature.</summary>

![kernel_c101_sdk_900 18 ddg](https://user-images.githubusercontent.com/7417022/105248125-b8ac8480-5b2a-11eb-929e-3f4f8472a709.png)

![kernel_c101_sdk_900 18 occupancy-preserving-ilp nodesup ddg](https://user-images.githubusercontent.com/7417022/105248134-bc400b80-5b2a-11eb-82b9-d96739ec2091.png)
</details>