### PR TITLE
Add reduced latency pass patch

### DIFF
--- a/example/llvm7-CPU2006-cfg/sched.ini
+++ b/example/llvm7-CPU2006-cfg/sched.ini
@@ -14,6 +14,32 @@ PRINT_SPILL_COUNTS YES
 # NO
 USE_TWO_PASS NO
 
+# Order of passes to run delimited by a comma with no space. Only enabled with
+# USE_TWO_PASS YES. Note that if both the regular ILP Pass and the ILP Reduced
+# Latency Pass are enabled then only timed out regions in the regular ILP pass
+# will be selected to be re-schedule in the Reduced Latency Pass.
+# VALUES:
+# OCC - Occupancy Pass
+# ILP - Regular ILP Pass
+# ILP_RL - ILP Reduced Latency Pass
+# Valid orderings: OCC,ILP or OCC,ILP_RL or OCC,ILP,ILP_RL
+PASS_ORDER OCC,ILP
+
+# If latency for an edge is greater than this amount then reduce the latency by
+# LATENCY_DIVISOR.
+LATENCY_TARGETS 1
+
+# The amount to divide the original latency by.
+LATENCY_DIVISOR 1
+
+# The minimum amount latency can be reduced to.
+LATENCY_MINIMUM 1
+
+# Enable a final pass with original latencies to gather compile-time data since
+# the ILP Reduce Latency pass will have invalid schedule lengths. In this pass
+# only the sequential list scheduler will be enabled and enumerator disabled.
+COMPILE_TIME_DATA_PASS NO
+
 # These 3 flags control which schedulers will be used.
 # Each one can be individually toggled. The heuristic
 # list scheduler or ACO must be run before the

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -14,6 +14,32 @@ PRINT_SPILL_COUNTS YES
 # NO
 USE_TWO_PASS NO
 
+# Order of passes to run delimited by a comma. Only enabled with
+# USE_TWO_PASS YES. Note that if both the regular ILP Pass and the ILP Reduced
+# Latency Pass are enabled then only timed out regions in the regular ILP pass
+# will be selected to be re-schedule in the Reduced Latency Pass.
+# VALUES:
+# 1 - Occupancy Pass
+# 2 - Regular ILP Pass
+# 3 - ILP Reduced Latency Pass
+# Valid orderings: 1,2 or 1,3 or 1,2,3.
+PASS_ORDER 1,2
+
+# If latency for an edge is greater than this amount then reduce the latency by
+# LATENCY_DIVISOR.
+LATENCY_TARGETS 1
+
+# The amount to divide the original latency by.
+LATENCY_DIVISOR 1
+
+# The minimum amount latency can be reduced to.
+LATENCY_MINIMUM 1
+
+# Enable a final pass with original latencies to gather compile-time data since
+# the ILP Reduce Latency pass will have invalid schedule lengths. In this pass
+# only the sequential list scheduler will be enabled and enumerator disabled.
+COMPILE_TIME_DATA_PASS NO
+
 # These 3 flags control which schedulers will be used.
 # Each one can be individually toggled. The heuristic
 # list scheduler or ACO must be run before the

--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -14,16 +14,16 @@ PRINT_SPILL_COUNTS YES
 # NO
 USE_TWO_PASS NO
 
-# Order of passes to run delimited by a comma. Only enabled with
+# Order of passes to run delimited by a comma with no space. Only enabled with
 # USE_TWO_PASS YES. Note that if both the regular ILP Pass and the ILP Reduced
 # Latency Pass are enabled then only timed out regions in the regular ILP pass
 # will be selected to be re-schedule in the Reduced Latency Pass.
 # VALUES:
-# 1 - Occupancy Pass
-# 2 - Regular ILP Pass
-# 3 - ILP Reduced Latency Pass
-# Valid orderings: 1,2 or 1,3 or 1,2,3.
-PASS_ORDER 1,2
+# OCC - Occupancy Pass
+# ILP - Regular ILP Pass
+# ILP_RL - ILP Reduced Latency Pass
+# Valid orderings: OCC,ILP or OCC,ILP_RL or OCC,ILP,ILP_RL
+PASS_ORDER OCC,ILP
 
 # If latency for an edge is greater than this amount then reduce the latency by
 # LATENCY_DIVISOR.

--- a/include/opt-sched/Scheduler/sched_region.h
+++ b/include/opt-sched/Scheduler/sched_region.h
@@ -133,7 +133,7 @@ public:
   SPILL_COST_FUNCTION GetSpillCostFunc();
 
   // Initialize variables for the second pass of the two-pass-optsched
-  void InitSecondPass();
+  void InitSecondPass(bool EnableMutations);
 
   // Initialize variables to reflect that we are using two-pass version of
   // algorithm
@@ -142,6 +142,9 @@ public:
   bool isTwoPassEnabled() const { return TwoPassEnabled_; }
 
   bool IsSecondPass() const { return isSecondPass_; }
+
+  bool enumFoundSchedule() { return EnumFoundSchedule; }
+  void setEnumFoundSchedule() { EnumFoundSchedule = true; }
 
 private:
   // The algorithm to use for calculated lower bounds.
@@ -170,6 +173,13 @@ private:
 
   // Used for two-pass-optsched to enable second pass functionalies.
   bool isSecondPass_;
+
+  /// If mutations are enabled then the sequential list scheduler must ignore
+  /// artificial edges when scheduling then add them back in after scheduling.
+  bool EnableMutations;
+
+  /// Indicate whether the B&B enumerator found any schedule.
+  bool EnumFoundSchedule;
 
   // The absolute cost lower bound to be used as a ref for normalized costs.
   InstCount costLwrBound_ = 0;

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -932,6 +932,9 @@ void BBWithSpill::UpdtOptmlSchedScndPss(InstSchedule *crntSched,
     SetBestSchedLength(crntSched->GetCrntLngth());
     enumBestSched_->Copy(crntSched);
     bestSched_ = enumBestSched_;
+
+    if (!enumFoundSchedule())
+      setEnumFoundSchedule();
   }
 }
 

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -866,13 +866,8 @@ void SchedRegion::CmputLwrBounds_(bool useFileBounds) {
 
     delete rlxdSchdulr;
     delete rvrsRlxdSchdulr;
-  } else {
-    if (dataDepGraph_->GetInstCnt() > schedLwrBound_)
-      Logger::Fatal(
-          "Previous schedule lower bound is %d but new lower bound is %d",
-          schedLwrBound_, dataDepGraph_->GetInstCnt());
+  } else
     schedLwrBound_ = dataDepGraph_->GetInstCnt();
-  }
 
   if (useFileBounds)
     UseFileBounds_();

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -51,7 +51,7 @@ ScheduleDAGOptSchedGCN::ScheduleDAGOptSchedGCN(
 void ScheduleDAGOptSchedGCN::initSchedulers() {
   // SchedPasses.push_back(GCNMaxOcc);
   // Add passes in the corresponding order that they are inserted.
-  for (auto const &Pass : PassOrder) {
+  for (const auto &Pass : PassOrder) {
     if (Pass == "OCC") // MinRP pass
       SchedPasses.push_back(OptSchedMaxOcc);
     else if (Pass == "ILP") // Regular ILP Pass

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -74,7 +74,7 @@ void ScheduleDAGOptSchedGCN::finalizeSchedule() {
   if (TwoPassEnabled && OptSchedEnabled) {
     initSchedulers();
     RescheduleRegions.resize(Regions.size());
-    RescheduleRegions.reset();
+    RescheduleRegions.set();
 
     LLVM_DEBUG(dbgs() << "Starting two pass scheduling approach\n");
     TwoPassSchedulingStarted = true;

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -52,11 +52,11 @@ void ScheduleDAGOptSchedGCN::initSchedulers() {
   // SchedPasses.push_back(GCNMaxOcc);
   // Add passes in the corresponding order that they are inserted.
   for (auto const &Pass : PassOrder) {
-    if (Pass == "1") // MinRP pass
+    if (Pass == "OCC") // MinRP pass
       SchedPasses.push_back(OptSchedMaxOcc);
-    else if (Pass == "2") // Regular ILP Pass
+    else if (Pass == "ILP") // Regular ILP Pass
       SchedPasses.push_back(OptSchedBalanced);
-    else if (Pass == "3") // ILP Reduced Latency Pass
+    else if (Pass == "ILP_RL") // ILP Reduced Latency Pass
       SchedPasses.push_back(OptSchedReducedLatency);
     else
       llvm::report_fatal_error("Invalid value for pass order: " + Pass, false);

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -49,14 +49,23 @@ ScheduleDAGOptSchedGCN::ScheduleDAGOptSchedGCN(
     : ScheduleDAGOptSched(C, std::move(S)) {}
 
 void ScheduleDAGOptSchedGCN::initSchedulers() {
-  // Add passes
-
   // SchedPasses.push_back(GCNMaxOcc);
+  // Add passes in the corresponding order that they are inserted.
+  for (auto const &Pass : PassOrder) {
+    if (Pass == "1") // MinRP pass
+      SchedPasses.push_back(OptSchedMaxOcc);
+    else if (Pass == "2") // Regular ILP Pass
+      SchedPasses.push_back(OptSchedBalanced);
+    else if (Pass == "3") // ILP Reduced Latency Pass
+      SchedPasses.push_back(OptSchedReducedLatency);
+    else
+      llvm::report_fatal_error("Invalid value for pass order: " + Pass, false);
+  }
 
-  // First
-  SchedPasses.push_back(OptSchedMaxOcc);
-  // Second
-  SchedPasses.push_back(OptSchedBalanced);
+  // Also run the sequential scheduler with regular latencies to get the
+  // actual schedule length
+  if (CompileTimeDataPass)
+    SchedPasses.push_back(OptSchedSeqScheduler);
 }
 
 // Execute scheduling passes.
@@ -64,6 +73,8 @@ void ScheduleDAGOptSchedGCN::initSchedulers() {
 void ScheduleDAGOptSchedGCN::finalizeSchedule() {
   if (TwoPassEnabled && OptSchedEnabled) {
     initSchedulers();
+    RescheduleRegions.resize(Regions.size());
+    RescheduleRegions.reset();
 
     LLVM_DEBUG(dbgs() << "Starting two pass scheduling approach\n");
     TwoPassSchedulingStarted = true;
@@ -118,9 +129,21 @@ void ScheduleDAGOptSchedGCN::runSchedPass(SchedPassStrategy S) {
     break;
   case OptSchedMaxOcc:
     scheduleOptSchedMaxOcc();
+    Logger::Event("PassFinished", "num", 1);
     break;
   case OptSchedBalanced:
+    RecordTimedOutRegions = true;
     scheduleOptSchedBalanced();
+    RecordTimedOutRegions = false;
+    Logger::Event("PassFinished", "num", 2);
+    break;
+  case OptSchedReducedLatency:
+    scheduleWithReducedLatencies();
+    Logger::Event("PassFinished", "num", 3);
+    break;
+  case OptSchedSeqScheduler:
+    scheduleWithSeqScheduler();
+    Logger::Event("PassFinished", "num", 4);
     break;
   }
 }

--- a/lib/Wrapper/AMDGPU/GCNOptSched.h
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.h
@@ -15,7 +15,13 @@ namespace opt_sched {
 
 class ScheduleDAGOptSchedGCN : public ScheduleDAGOptSched {
 private:
-  enum SchedPassStrategy { GCNMaxOcc, OptSchedMaxOcc, OptSchedBalanced };
+  enum SchedPassStrategy {
+    GCNMaxOcc,
+    OptSchedMaxOcc,
+    OptSchedBalanced,
+    OptSchedReducedLatency,
+    OptSchedSeqScheduler
+  };
 
   // Vector of scheduling passes to execute.
   SmallVector<SchedPassStrategy, 4> SchedPasses;

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
@@ -451,14 +451,30 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
       const auto &InstName = DAG->TII->getName(instr->getOpcode());
       const auto &InstType = MM->GetInstTypeByName(InstName);
       Latency = MM->GetLatency(InstType, DepType);
-    } else if (ltncyPrcsn_ == LTP_ROUGH) // rough latency = llvm latency
+    } else if (ltncyPrcsn_ == LTP_ROUGH) { // rough latency = llvm latency
       Latency = I->getLatency();
-    else
+      // If latency is greater than a specified amount then reduce the latency
+      // by a certain amount
+      if (DAG->reducedLatencyPassStarted() &&
+          Latency > DAG->getLatencyTarget()) {
+        const string &InstFromName = DAG->TII->getName(instr->getOpcode());
+        const MachineInstr *ToInstr = I->getSUnit()->getInstr();
+        const string &InstToName = DAG->TII->getName(ToInstr->getOpcode());
+        int16_t OldLatency = Latency;
+        Latency /= DAG->getLatencyDivisor();
+        if (Latency < DAG->getLatencyMinimun())
+          Latency = LatencyMinimun;
+
+        Logger::Event("ReduceLatency", "FromInstruction", InstFromName.c_str(),
+                      "ToInstruction", InstToName.c_str(), "OriginalLatency",
+                      OldLatency, "NewLatency", Latency);
+      }
+    } else
       Latency = 1; // unit latency = ignore ilp
 
     CreateEdge_(SU.NodeNum, I->getSUnit()->NodeNum, Latency, DepType,
                 IsArtificial);
-  }
+    }
 }
 
 void OptSchedDDGWrapperBasic::convertSUnit(const SUnit &SU) {

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
@@ -453,8 +453,8 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
       Latency = MM->GetLatency(InstType, DepType);
     } else if (ltncyPrcsn_ == LTP_ROUGH) { // rough latency = llvm latency
       Latency = I->getLatency();
-      // If latency is greater than a specified amount then reduce the latency
-      // by a certain amount
+      // If latency is above a specified target then reduce the latency
+      // by the specified divisor
       if (DAG->reducedLatencyPassStarted() &&
           Latency > DAG->getLatencyTarget()) {
         const string &InstFromName = DAG->TII->getName(instr->getOpcode());
@@ -463,7 +463,7 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
         int16_t OldLatency = Latency;
         Latency /= DAG->getLatencyDivisor();
         if (Latency < DAG->getLatencyMinimun())
-          Latency = LatencyMinimun;
+          Latency = DAG->getLatencyMinimun();
 
         Logger::Event("ReduceLatency", "FromInstruction", InstFromName.c_str(),
                       "ToInstruction", InstToName.c_str(), "OriginalLatency",

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -865,7 +865,14 @@ void ScheduleDAGOptSched::scheduleOptSchedMinRP() {
   LengthTimeout = FirstPassLengthTimeout;
   HeurSchedType = SCHED_LIST;
 
+  // Disable relaxed scheduling pruning since we already know what the minimum
+  // length should be in the occupancy pass
+  bool Temp1 = PruningStrategy.rlxd;
+  PruningStrategy.rlxd = false;
+
   schedule();
+
+  PruningStrategy.rlxd = Temp1;
 }
 
 void ScheduleDAGOptSched::scheduleOptSchedBalanced() {
@@ -909,7 +916,7 @@ void ScheduleDAGOptSched::scheduleWithReducedLatencies() {
   // We do not want to run the enumerator again for the regions that does not
   // need re-scheduling.
   if (!RescheduleRegions[RegionNumber + 1]) {
-    RegionNumber += 1;
+    RegionNumber++;
     return;
   }
 

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -257,11 +257,11 @@ void ScheduleDAGOptSched::SetupLLVMDag() {
 void ScheduleDAGOptSched::initSchedulers() {
   // Add passes in the corresponding order that they are inserted.
   for (auto const &Pass : PassOrder) {
-    if (Pass == "1") // MinRP pass
+    if (Pass == "OCC") // MinRP pass
       SchedPasses.push_back(OptSchedMinRP);
-    else if (Pass == "2") // Regular ILP Pass
+    else if (Pass == "ILP") // Regular ILP Pass
       SchedPasses.push_back(OptSchedBalanced);
-    else if (Pass == "3") // ILP Reduced Latency Pass
+    else if (Pass == "ILP_RL") // ILP Reduced Latency Pass
       SchedPasses.push_back(OptSchedReducedLatency);
     else
       llvm::report_fatal_error("Invalid value for pass order: " + Pass, false);

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -256,7 +256,7 @@ void ScheduleDAGOptSched::SetupLLVMDag() {
 // Add the two passes used for the two pass scheduling approach
 void ScheduleDAGOptSched::initSchedulers() {
   // Add passes in the corresponding order that they are inserted.
-  for (auto const &Pass : PassOrder) {
+  for (const auto &Pass : PassOrder) {
     if (Pass == "OCC") // MinRP pass
       SchedPasses.push_back(OptSchedMinRP);
     else if (Pass == "ILP") // Regular ILP Pass


### PR DESCRIPTION
This patch adds a reduced latency pass that can be used with the two-pass algorithm. This new pass is intended to be done after the Occupancy pass and can be used with or in place of the ILP pass.

The new reduced latency pass can be enabled by modifying the `sched.ini` file and modifying the `PASS_ORDER` setting to include the value `3`. There are also settings to tune the pass such as `LATENCY_TARGETS`, `LATENCY_DIVISOR`, and `LATENCY_MINIMUM`.

Since this pass reduces latencies, we will not get accurate schedule length values so an additional pass can be enabled by setting `COMPILE_TIME_DATA_PASS YES`. This additional pass runs through the schedule again with normal latencies by using the sequential list scheduler. Note that this will increase compile-time due to adding an additional pass. If you do not care about the compile-time data of our scheduler during the reduced latency pass then this pass can be left disabled.

Additionally, in this patch range tightening and relaxed scheduling pruning during enumeration have also been disabled in the Occupancy pass. Since all latencies are 1 in the occupancy pass, we know the min/max length of schedules thus do not need length-related pruning. The lower bound length calculation done before enumerating has also been disabled in any regions with max latency <= 1 since in these cases the lower bound length should be the number of instructions in the region.