### PR TITLE
Fix duplicate edges being copied to device and reduce cudaMemcpy calls

### DIFF
--- a/include/opt-sched/Scheduler/aco.h
+++ b/include/opt-sched/Scheduler/aco.h
@@ -24,7 +24,7 @@ typedef double pheromone_t;
 // If set to 1 ACO is run on device
 #define DEV_ACO 1
 // setting to 1 locks ACO to iterations_without_improvement iterations
-#define RUNTIME_TESTING 1
+#define RUNTIME_TESTING 0
 // Minimum region node count. Doesn't make sence to launch DEV_ACO on small rgns
 #define REGION_MIN_SIZE 50
 // use edge count to approximate memory usage, using nodeCnt reflect

--- a/include/opt-sched/Scheduler/data_dep.h
+++ b/include/opt-sched/Scheduler/data_dep.h
@@ -161,6 +161,12 @@ protected:
   // An array of instructions
   SchedInstruction *insts_;
 
+  // If compiling on device, keep track of the pointers for all edges added
+  // to facilitate a fast copy of edges to device
+  std::vector<GraphEdge *> *edges_;
+  // Device array of all GraphEdges
+  GraphEdge *dev_edges_;
+
   // The number of issue types of the machine which this graph uses.
   int16_t issuTypeCnt_;
 
@@ -338,6 +344,8 @@ public:
   void CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads = 0);
   // Calls cudaFree on all arrays/objects that were allocated with cudaMalloc
   void FreeDevicePointers(int numThreads);
+  // frees the dev_edges_ array, for some reason did not work in the destructor
+  void FreeDevEdges();
 
 protected:
   // TODO(max): Get rid of this.

--- a/include/opt-sched/Scheduler/graph.h
+++ b/include/opt-sched/Scheduler/graph.h
@@ -287,7 +287,8 @@ public:
 
   // Copy GraphNode arrays/pointers to device
   void CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
-		            InstCount instCnt);
+		            InstCount instCnt, std::vector<GraphEdge *> *edges,
+                            GraphEdge *dev_edges);
   // Calls cudaFree on all arrays/objects that were allocated with cudaMalloc
   void FreeDevicePointers();
 

--- a/include/opt-sched/Scheduler/sched_basic_data.h
+++ b/include/opt-sched/Scheduler/sched_basic_data.h
@@ -549,7 +549,8 @@ public:
   // the device nodes_ array to set nodes_ in GraphNode
   void CopyPointersToDevice(SchedInstruction *dev_inst, GraphNode **dev_nodes, 
 		            InstCount instCnt, RegisterFile *dev_regFiles, 
-                            int numThreads = 0);
+                            int numThreads, std::vector<GraphEdge *> *edges,
+                            GraphEdge *dev_edges);
   // Calls cudaFree on all arrays/objects that were allocated with cudaMalloc
   void FreeDevicePointers(int numThreads);
   // Allocates arrays used for storing individual values for each thread in

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -3643,7 +3643,6 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
 		       sizeof(SchedInstruction **),
 	  	       cudaMemcpyHostToDevice));
   // update nodes_ values on device
-  SchedInstruction *dev_inst;
   for (InstCount i = 0; i < instCnt_; i++) 
     dev_DDG->nodes_[i] = &dev_insts[i];
   gpuErrchk(cudaMemPrefetchAsync(dev_DDG->nodes_, memSize, 0));
@@ -3716,7 +3715,7 @@ void DataDepGraph::FreeDevicePointers(int numThreads) {
 
 void DataDepGraph::FreeDevEdges() {
   if (dev_edges_)
-    cudaFree(dev_edges)
+    cudaFree(dev_edges_);
 }
 
 /*

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -55,6 +55,7 @@ DataDepStruct::DataDepStruct(MachineModel *machMdl) {
   frwrdLwrBounds_ = NULL;
   bkwrdLwrBounds_ = NULL;
   includesUnpipelined_ = false;
+  edges_ = NULL;
 }
 
 __host__ __device__
@@ -64,6 +65,8 @@ DataDepStruct::~DataDepStruct() {
     delete[] frwrdLwrBounds_;
   if (bkwrdLwrBounds_ != NULL)
     delete[] bkwrdLwrBounds_;
+  if (edges_)
+    delete edges_;
 }
 
 __host__ __device__
@@ -964,6 +967,14 @@ void DataDepGraph::CreateEdge(SchedInstruction *frmNode,
 
   GraphEdge *newEdg = new GraphEdge(frmNode->GetNum(), toNode->GetNum(), 
 		                    ltncy, depType);
+  // If compiling on device, keep track of the pointers to all edges
+  if (DEV_ACO && instCnt_ >= 50) {
+    // if the edges_ vector has not been created, create it
+    if (!edges_)
+      edges_ = new std::vector<GraphEdge *>();
+    edges_->push_back(newEdg);
+  }
+
   edgeCnt_++;
   frmNode->AddScsr(newEdg);
   toNode->AddPrdcsr(newEdg);
@@ -1007,6 +1018,13 @@ void DataDepGraph::CreateEdge_(InstCount frmNodeNum, InstCount toNodeNum,
 #endif
     edge = new GraphEdge(frmNode->GetNum(), toNode->GetNum(), ltncy, depType,
                          IsArtificial);
+    // If compiling on device, keep track of the pointers to all edges
+    if (DEV_ACO && instCnt_ >= 50) {
+      // if the edges_ vector has not been created, create it
+      if (!edges_)
+        edges_ = new std::vector<GraphEdge *>();
+      edges_->push_back(edge);
+    }
     edgeCnt_++;
     frmNode->AddScsr(edge);
     toNode->AddPrdcsr(edge);
@@ -3653,12 +3671,28 @@ void DataDepGraph::CopyPointersToDevice(DataDepGraph *dev_DDG, int numThreads) {
   // Also copy each RegFile's pointers
   for (InstCount i = 0; i < machMdl_->GetRegTypeCnt(); i++)
     RegFiles[i].CopyPointersToDevice(&dev_DDG->RegFiles[i]);
+  // Collect all GraphEdges into one host array, copy it to device
+  Logger::Info("Copying all edges to device");
+  memSize = sizeof(GraphEdge) * edges_->size();
+  // Will hold all host edges in one array to be copied to device in one copy
+  GraphEdge *host_edges = (GraphEdge *)malloc(memSize);
+  gpuErrchk(cudaMalloc(&dev_edges_, memSize));
+  // iterate through all pointers to edges and copy them into one host array
+  memSize = sizeof(GraphEdge);
+  for (uint i = 0; i < edges_->size(); i++)
+    memcpy(&host_edges[i], edges_->at(i), memSize);
+  // Copy host_edges to device and delete the host_edges array
+  memSize = sizeof(GraphEdge) * edges_->size();
+  gpuErrchk(cudaMemcpy(dev_edges_, host_edges, memSize, 
+                       cudaMemcpyHostToDevice));
+  free(host_edges);
   // Copy SchedInstruction/GraphNode pointers and link them to device inst
-  // and update RegFiles poitner to dev_regFiles
+  // and update RegFiles pointer to dev_regFiles
   Logger::Info("Copying SchedInstructions to device");
   for (InstCount i = 0; i < instCnt_; i++)
     insts_[i].CopyPointersToDevice(&dev_DDG->insts_[i], dev_DDG->nodes_, 
-		                   instCnt_, dev_regFiles, numThreads);
+		                   instCnt_, dev_regFiles, numThreads,
+                                   edges_, dev_edges_);
   memSize = sizeof(SchedInstruction) * instCnt_;
   gpuErrchk(cudaMemPrefetchAsync(dev_insts, memSize, 0));
   memSize = sizeof(RegisterFile) * machMdl_->GetRegTypeCnt();
@@ -3678,6 +3712,11 @@ void DataDepGraph::FreeDevicePointers(int numThreads) {
     insts_[i].FreeDevicePointers(numThreads);
   cudaFree(insts_);
   cudaFree(nodes_);
+}
+
+void DataDepGraph::FreeDevEdges() {
+  if (dev_edges_)
+    cudaFree(dev_edges)
 }
 
 /*

--- a/lib/Scheduler/graph.cpp
+++ b/lib/Scheduler/graph.cpp
@@ -366,7 +366,6 @@ void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
                                      GraphEdge *dev_edges) {
   size_t memSize;
   int index;
-  std::vector<GraphEdge *>::iterator it;
   // Copy scsrLst_ to device
   PriorityArrayList<GraphEdge *> *dev_scsrLst;
   memSize = sizeof(PriorityArrayList<GraphEdge *>);

--- a/lib/Scheduler/graph.cpp
+++ b/lib/Scheduler/graph.cpp
@@ -361,9 +361,12 @@ void GraphNode::LogScsrLst() {
 }
 
 void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
-                                     InstCount instCnt) {
-  size_t memSize; 
-  InstCount *dev_elmnts;
+                                     InstCount instCnt, 
+                                     std::vector<GraphEdge *> *edges,
+                                     GraphEdge *dev_edges) {
+  size_t memSize;
+  int index;
+  std::vector<GraphEdge *>::iterator it;
   // Copy scsrLst_ to device
   PriorityArrayList<GraphEdge *> *dev_scsrLst;
   memSize = sizeof(PriorityArrayList<GraphEdge *>);
@@ -374,9 +377,7 @@ void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
 		       cudaMemcpyHostToDevice));
   // Copy elmnts_ and keys
   unsigned long *dev_keys;
-  GraphEdge **dev_edges;
-  GraphEdge *dev_edge;
-  GraphEdge *host_edge;
+  GraphEdge **dev_elmnts;
   if (scsrLst_->maxSize_ > 0) {
     memSize = sizeof(unsigned long) * scsrLst_->maxSize_;
     gpuErrchk(cudaMalloc(&dev_keys, memSize));
@@ -385,30 +386,21 @@ void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
     gpuErrchk(cudaMemcpy(&dev_node->scsrLst_->keys_, &dev_keys,
 			 sizeof(unsigned long *), cudaMemcpyHostToDevice));
     memSize = sizeof(GraphEdge *) * scsrLst_->maxSize_;
-    gpuErrchk(cudaMallocManaged(&dev_edges, memSize));
-    gpuErrchk(cudaMemcpy(dev_edges, scsrLst_->elmnts_, memSize,
-			 cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(&dev_node->scsrLst_->elmnts_, &dev_edges,
+    gpuErrchk(cudaMallocManaged(&dev_elmnts, memSize));
+    gpuErrchk(cudaMemcpy(&dev_node->scsrLst_->elmnts_, &dev_elmnts,
 			 sizeof(GraphEdge **), cudaMemcpyHostToDevice));
-    // Copy all GraphEdges to device
-    memSize = sizeof(GraphEdge) * scsrLst_->size_;
-    // Alloc host and dev mem to prepare all GraphEdges for one cudaCopy
-    host_edge = (GraphEdge *)malloc(memSize);
-    gpuErrchk(cudaMalloc(&dev_edge, memSize));
-    // prepare host array of edges
-    memSize = sizeof(GraphEdge);
-    for (InstCount i = 0; i < scsrLst_->size_; i++)
-      memcpy(&host_edge[i], scsrLst_->elmnts_[i], memSize);
-    // copy host array to device array, delete host array
-    memSize = sizeof(GraphEdge) * scsrLst_->size_;
-    gpuErrchk(cudaMemcpy(dev_edge, host_edge, memSize, cudaMemcpyHostToDevice));
-    free(host_edge);
     // update elmnts_ pointers to dev array
-    for (InstCount i = 0; i < scsrLst_->size_; i++)
-      dev_edges[i] = &dev_edge[i];
+    for (InstCount i = 0; i < scsrLst_->size_; i++) {
+      // find the matching pointer in the array of edge pointers
+      for (uint x = 0; x < edges->size(); x++)
+        if (edges->at(x) == scsrLst_->elmnts_[i])
+          index = x;
+      // set the dev_elmnts pointer to the corresponding dev_edges pointer
+      dev_elmnts[i] = &dev_edges[index];
+    }
     // Make sure new dev_edges values are copied before kernel start
     memSize = sizeof(GraphEdge *) * scsrLst_->maxSize_;
-    gpuErrchk(cudaMemPrefetchAsync(dev_edges, memSize, 0));
+    gpuErrchk(cudaMemPrefetchAsync(dev_elmnts, memSize, 0));
   }
   memSize = sizeof(PriorityArrayList<GraphEdge *>);
   gpuErrchk(cudaMemPrefetchAsync(dev_scsrLst, memSize, 0));
@@ -424,49 +416,35 @@ void GraphNode::CopyPointersToDevice(GraphNode *dev_node, GraphNode **dev_nodes,
   // Copy elmnts_
   if (prdcsrLst_->maxSize_ > 0) {
     memSize = sizeof(GraphEdge *) * prdcsrLst_->maxSize_;
-    gpuErrchk(cudaMallocManaged(&dev_edges, memSize));
-    gpuErrchk(cudaMemcpy(dev_edges, prdcsrLst_->elmnts_, memSize,
-                         cudaMemcpyHostToDevice));
-    gpuErrchk(cudaMemcpy(&dev_node->prdcsrLst_->elmnts_, &dev_edges,
+    gpuErrchk(cudaMallocManaged(&dev_elmnts, memSize));
+    gpuErrchk(cudaMemcpy(&dev_node->prdcsrLst_->elmnts_, &dev_elmnts,
                          sizeof(GraphEdge **), cudaMemcpyHostToDevice));
-    // Copy all GraphEdges to device
-    memSize = sizeof(GraphEdge) * prdcsrLst_->size_;
-    // Alloc host and dev mem to prepare all GraphEdges for one cudaCopy
-    host_edge = (GraphEdge *)malloc(memSize);
-    gpuErrchk(cudaMalloc(&dev_edge, memSize));
-    // prepare host array of edges
-    memSize = sizeof(GraphEdge);
-    for (InstCount i = 0; i < prdcsrLst_->size_; i++)
-      memcpy(&host_edge[i], prdcsrLst_->elmnts_[i], memSize);
-    // copy host array to device array, delete host array
-    memSize = sizeof(GraphEdge) * prdcsrLst_->size_;
-    gpuErrchk(cudaMemcpy(dev_edge, host_edge, memSize, cudaMemcpyHostToDevice));
-    free(host_edge);
     // update elmnts_ pointers to dev array
-    for (InstCount i = 0; i < prdcsrLst_->size_; i++)
-      dev_edges[i] = &dev_edge[i];
+    for (InstCount i = 0; i < prdcsrLst_->size_; i++) {
+      // find the matching pointer in the array of edge pointers
+      for (uint x = 0; x < edges->size(); x++)
+        if (edges->at(x) == prdcsrLst_->elmnts_[i])
+          index = x;
+      // set the dev_elmnts pointer to the corresponding dev_edges pointer
+      dev_elmnts[i] = &dev_edges[index];
+    }
     // Make sure new dev_edges values are copied before kernel start
     memSize = sizeof(GraphEdge *) * prdcsrLst_->maxSize_;
-    gpuErrchk(cudaMemPrefetchAsync(dev_edges, memSize, 0));
+    gpuErrchk(cudaMemPrefetchAsync(dev_elmnts, memSize, 0));
   }
   memSize = sizeof(ArrayList<GraphEdge *>);
   gpuErrchk(cudaMemPrefetchAsync(dev_prdcsrLst, memSize, 0));
-  //Copy BitVector *isRcrsvScsr_
-  BitVector *dev_isRcrsvScsr;
-  unsigned long *dev_vctr;
   //set value of nodes_ to dev_insts_
   dev_node->nodes_ = dev_nodes;
 }
 
 void GraphNode::FreeDevicePointers() {
   if (scsrLst_) {
-    cudaFree(scsrLst_->elmnts_[0]);
     cudaFree(scsrLst_->elmnts_);
     cudaFree(scsrLst_->keys_);
     cudaFree(scsrLst_);
   }
   if (prdcsrLst_) {
-    cudaFree(prdcsrLst_->elmnts_[0]);
     cudaFree(prdcsrLst_->elmnts_);
     cudaFree(prdcsrLst_);
   }

--- a/lib/Scheduler/sched_basic_data.cpp
+++ b/lib/Scheduler/sched_basic_data.cpp
@@ -1071,7 +1071,9 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
                                             GraphNode **dev_nodes,
 					    InstCount instCnt, 
 					    RegisterFile *dev_regFiles,
-                                            int numThreads) {
+                                            int numThreads, 
+                                            std::vector<GraphEdge *> *edges,
+                                            GraphEdge *dev_edges) {
   dev_inst->RegFiles_ = dev_regFiles;
   size_t memSize;
   memSize = sizeof(InstCount) * prdcsrCnt_;
@@ -1093,7 +1095,8 @@ void SchedInstruction::CopyPointersToDevice(SchedInstruction *dev_inst,
   // Copy sortedScsrLst_
   InstCount *dev_elmnts;
   unsigned long *dev_keys;
-  GraphNode::CopyPointersToDevice((GraphNode *)dev_inst, dev_nodes, instCnt);
+  GraphNode::CopyPointersToDevice((GraphNode *)dev_inst, dev_nodes, instCnt,
+                                  edges, dev_edges);
   // make sure managed mem is copied to device before kernel start
   memSize = sizeof(InstCount *) * numThreads;
   gpuErrchk(cudaMemPrefetchAsync(dev_rdyCyclePerPrdcsr_, memSize, 0));

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -1058,6 +1058,9 @@ FUNC_RESULT SchedRegion::runACO(InstSchedule *ReturnSched,
     dev_DDG->FreeDevicePointers(NUMTHREADS);
     cudaFree(dev_DDG);
     cudaFree(dev_states);
+    // For some reason crashed OptSched to have this in the destructor
+    // so call to delete it here
+    dataDepGraph_->FreeDevEdges();
     // Ocasionally BBWithSpill deletes an empty pointer, which causes the next
     // kernel to report an invalid argument error after execution even
     // though the non issue error happens here. This call is to clear errors


### PR DESCRIPTION
This PR fixes the issue of two of each edge being copied to device and also reduces the amount of calls to cudaMemcpy. Now if we are going to be scheduling on device, pointers to all edges are stored in a vector named edges_ to keep track of all edges. Then during copy of DDG to device we use these pointers to copy over all edges into a host array of edges, and then copy them to device with only one cudaMemcpy call compared to two calls per instruction before.
I also changed the RUNTIME_TESTING define to 0 since I think the default state should not be limited in iterations.