### PR TITLE
Fixes a bug in SLIL cost computation on the device

### DIFF
--- a/include/opt-sched/Scheduler/bit_vector.h
+++ b/include/opt-sched/Scheduler/bit_vector.h
@@ -307,8 +307,7 @@ inline void WeightedBitVector::Dev_Reset() {
     vctr_[i] = 0;
   }
 
-  oneCnt_ = 0;
-	
+  oneCnt_ = 0;	
   wghtedCnt_ = 0;
 }
 

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -1187,7 +1187,7 @@ InstCount BBWithSpill::Dev_CmputCostForFunction(SPILL_COST_FUNCTION SpillCF) {
   }
   case SCF_SLIL: {
     InstCount SLILCost = 0; 
-    for (int i = 0; i < regTypeCnt_; i ++)
+    for (int i = 0; i < regTypeCnt_; i++)
       SLILCost += dev_sumOfLiveIntervalLengths_[i][GLOBALTID];
     return SLILCost;
   }
@@ -1507,8 +1507,12 @@ void BBWithSpill::CopyPointersToDevice(SchedRegion* dev_rgn, int numThreads) {
   int unitCnt, indx = 0;
   // Find totUnitCnt to determine size of vctr for all liveRegs_
   int totUnitCnt = 0;
-  for (int i = 0; i < regTypeCnt_; i++)
+  for (int i = 0; i < regTypeCnt_; i++) {
     totUnitCnt += liveRegs_[i].GetUnitCnt();
+    // set one bit, so oneCnt_ is nonzero to force reset of vctrs on device
+    if (liveRegs_[i].GetUnitCnt() > 0)
+      liveRegs_[i].SetBit(0,true,1);
+  }
   // Allocate vctr for all dev_liveRegs
   memSize = totUnitCnt * sizeof(unsigned int) * numThreads;
   gpuErrchk(cudaMalloc((void**)&dev_vctr, memSize));
@@ -1557,8 +1561,12 @@ void BBWithSpill::CopyPointersToDevice(SchedRegion* dev_rgn, int numThreads) {
   WeightedBitVector *dev_temp_livePhysRegs;
   // Find totUnitCnt to determine size of vctr for all livePhysRegs_
   totUnitCnt = 0;
-  for (int i = 0; i < regTypeCnt_; i++)
+  for (int i = 0; i < regTypeCnt_; i++) {
     totUnitCnt += livePhysRegs_[i].GetUnitCnt();
+    // set one bit, so oneCnt_ is nonzero to force reset of vctrs on device
+    if (livePhysRegs_[i].GetUnitCnt() > 0)
+      livePhysRegs_[i].SetBit(0,true,1);
+  }
   // Allocate vctr for all dev_livePhysRegs
   memSize = totUnitCnt * sizeof(unsigned int) * numThreads;
   gpuErrchk(cudaMalloc((void**)&dev_vctr, memSize));


### PR DESCRIPTION
The issue was that after copying over the WeightedBitVector for liveRegs_ and livePhysRegs_ and allocating the device array for vctr_ for all of the WBV, since oneCnt_ was set to 0, WBV::Dev_Reset() was not setting the values of each vctr_ array to 0. This fix forces Dev_Reset to initialize all values in both vctr_ arrays to 0 by setting the first bit to true, and making oneCnt_ equal to 1.