### PR TITLE
Benchmark Runner Scripts

### DIFF
--- a/util/runners/__init__.py
+++ b/util/runners/__init__.py
@@ -1,0 +1,2 @@
+from . import multirun
+from . import runwith

--- a/util/runners/datename
+++ b/util/runners/datename
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+date +'%F.%H.%M'

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -89,7 +89,7 @@ if __name__ == '__main__':
     main(
         outdir=Path(args.outdir),
         optsched_cfg=Path(args.optsched_cfg),
-        labels=args.labels,
+        labels=args.labels.split(','),
         withs=[runwith.parse_withs(with_) for with_ in getattr(args, 'with', [])],
         cmd=args.cmd if args.cmd != '-' else RUN_CMD,
         append_logs=args.append,

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -35,8 +35,8 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
     if validate_cmd:
         val_cmd = shlex.split(validate_cmd, comments=True)
         if not validate_cmd.endswith('#'):
-            val_cmd += logfiles
-        subprocess.run(shlex.join(val_cmd), cwd=outdir, check=True, shell=True)
+            val_cmd += map(str, logfiles)
+        subprocess.run(subprocess.list2cmdline(val_cmd), cwd=outdir, check=True, shell=True)
 
     if not analyze_files:
         analyze_files = [None] * len(analyze_cmds)
@@ -44,11 +44,12 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
     for analyze_cmd, outfile in zip(analyze_cmds, analyze_files):
         analyze_run = shlex.split(analyze_cmd, comments=True)
         if not analyze_cmd.endswith('#'):
-            analyze_run += logfiles
-        result = subprocess.run(shlex.join(analyze_run), cwd=outdir, capture_output=True, encoding='utf-8', shell=True)
+            analyze_run += map(str, logfiles)
+        result = subprocess.run(subprocess.list2cmdline(analyze_run), cwd=outdir,
+                                capture_output=True, encoding='utf-8', shell=True)
         if result.returncode != 0:
             print(
-                f'Analysis command {shlex.join(analyze_run)} failed with error code: {result.returncode}', file=sys.stderr)
+                f'Analysis command {subprocess.list2cmdline(analyze_run)} failed with error code: {result.returncode}', file=sys.stderr)
 
         print(result.stdout)
         print(result.stderr, file=sys.stderr)

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -36,7 +36,7 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
         val_cmd = shlex.split(validate_cmd, comments=True)
         if not validate_cmd.endswith('#'):
             val_cmd += logfiles
-        subprocess.run(val_cmd, cwd=outdir, check=True, stdout=subprocess.STDOUT, stderr=subprocess.STDERR)
+        subprocess.run(val_cmd, cwd=outdir, check=True)
 
     if not analyze_files:
         analyze_files = [None] * len(analyze_cmds)

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -26,7 +26,7 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
             optsched_cfg=optsched_cfg,
             label=label,
             with_=with_,
-            cmd=cmd,
+            cmd=[arg.replace('{{label}}', label) for arg in cmd],
             append_logs=append_logs,
             git_state=git_state,
         )
@@ -68,7 +68,7 @@ if __name__ == '__main__':
                         help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDCFG if it exists, else is required. The sched.ini is expected to be there')
     parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
     parser.add_argument('-L', '--labels', required=True,
-                        help='Comma separated labels to use for these runs. Must be equal to the number of --with flags')
+                        help='Comma separated labels to use for these runs. Must be equal to the number of --with flags. Any parts of the run command <cmd> will have the string {{label}} replaced with the label for the run.')
     parser.add_argument('--with', nargs='*', action='append', metavar='KEY=VALUE',
                         help="The sched.ini settings to set for each run. Each run's settings should have a new --with flag.")
     parser.add_argument(

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -36,7 +36,7 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
         val_cmd = shlex.split(validate_cmd, comments=True)
         if not validate_cmd.endswith('#'):
             val_cmd += logfiles
-        subprocess.run(val_cmd, cwd=outdir, check=True)
+        subprocess.run(shlex.join(val_cmd), cwd=outdir, check=True, shell=True)
 
     if not analyze_files:
         analyze_files = [None] * len(analyze_cmds)
@@ -45,7 +45,7 @@ def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[s
         analyze_run = shlex.split(analyze_cmd, comments=True)
         if not analyze_cmd.endswith('#'):
             analyze_run += logfiles
-        result = subprocess.run(analyze_run, cwd=outdir, capture_output=True, encoding='utf-8')
+        result = subprocess.run(shlex.join(analyze_run), cwd=outdir, capture_output=True, encoding='utf-8', shell=True)
         if result.returncode != 0:
             print(
                 f'Analysis command {shlex.join(analyze_run)} failed with error code: {result.returncode}', file=sys.stderr)

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--optsched-cfg',
                         required=OPTSCHEDCFG is None,
                         default=OPTSCHEDCFG,
-                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDENV if it exists, else is required. The sched.ini is expected to be there')
+                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDCFG if it exists, else is required. The sched.ini is expected to be there')
     parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
     parser.add_argument('-L', '--labels', required=True,
                         help='Comma separated labels to use for these runs. Must be equal to the number of --with flags')

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -86,8 +86,8 @@ if __name__ == '__main__':
                         help='The command (single string) to run after all runs to validate that the runs were correct. Defaults to the env variable VALIDATE_CMD. The output log files will be passed to the command, one additional arg for each run. To skip this, end the command with a bash comment #')
     parser.add_argument('--analyze', nargs='*', default=[ANALYZE_CMD] if ANALYZE_CMD else [],
                         help='The commands (each a single string) to run after all runs to analyze the runs and produce output. Defaults to the single command from the env variable ANALYZE_CMD. The output log files will be passed to each command, one additional arg for each run. To skip this, end the command with a bash comment #')
-    parser.add_argument('--analyze-files', nargs='*', default=[],
-                        help='The filenames to place the stdout of each analyze command.')
+    parser.add_argument('--analyze-files',
+                        help='The filenames to place the stdout of each analyze command, comma separated.')
 
     args = parser.parse_args()
 
@@ -101,5 +101,5 @@ if __name__ == '__main__':
         git_state=args.git_state,
         validate_cmd=args.validate,
         analyze_cmds=args.analyze,
-        analyze_files=args.analyze_files,
+        analyze_files=args.analyze_files.split(',') if args.analyze_files else [],
     )

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--validate', default=VALIDATE_CMD,
                         help='The command (single string) to run after all runs to validate that the runs were correct. Defaults to the env variable VALIDATE_CMD. The output log files will be passed to the command, one additional arg for each run.')
-    parser.add_argument('--analyze', nargs='*', default=[ANALYZE_CMD],
+    parser.add_argument('--analyze', nargs='*', default=[ANALYZE_CMD] if ANALYZE_CMD else [],
                         help='The commands (each a single string) to run after all runs to analyze the runs and produce output. Defaults to the single command from the env variable ANALYZE_CMD. The output log files will be passed to each command, one additional arg for each run.')
     parser.add_argument('--analyze-files', nargs='*', default=[],
                         help='The filenames to place the stdout of each analyze command.')

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from runners import runwith
+
+# %% Setup
+
+
+def main(outdir: Path, optsched_cfg: Path, labels: List[str], withs: List[Dict[str, str]], cmd: List[str], append_logs: bool = False, git_state: Optional[str] = None, validate_cmd: Optional[str] = None, analyze_cmds: List[str] = [], analyze_files: List[str] = []):
+    assert len(labels) == len(withs)
+    assert not analyze_files or len(analyze_files) == len(analyze_cmds)
+
+    outdir = outdir.resolve()
+    logfiles = []
+
+    for label, with_ in zip(labels, withs):
+        print(f'Running {label} with settings:', ' '.join(f'{k}={v}' for k, v in with_.items()))
+        logfile = runwith.main(
+            outdir=outdir,
+            optsched_cfg=optsched_cfg,
+            label=label,
+            with_=with_,
+            cmd=cmd,
+            append_logs=append_logs,
+            git_state=git_state,
+        )
+        logfiles.append(logfile)
+
+    if validate_cmd:
+        subprocess.run(validate_cmd + ' ' + shlex.join(logfiles), cwd=outdir,
+                       check=True, stdout=subprocess.STDOUT, stderr=subprocess.STDERR)
+
+    if not analyze_files:
+        analyze_files = [None] * len(analyze_cmds)
+
+    for analyze_cmd, outfile in zip(analyze_cmds, analyze_files):
+        result = subprocess.run(analyze_cmd + ' ' + shlex.join(logfiles), cwd=outdir,
+                                capture_output=True, encoding='utf-8')
+        if result.returncode != 0:
+            print(
+                f'Analysis command {shlex.join(analyze_cmd)} failed with error code: {result.returncode}', file=sys.stderr)
+
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        if outfile:
+            with open(outdir / outfile, 'w') as f:
+                f.write(result.stdout)
+
+
+# %% Main
+if __name__ == '__main__':
+    OPTSCHEDCFG = os.getenv('OPTSCHEDCFG')
+    RUN_CMD = os.getenv('RUN_CMD')
+    RUN_CMD = shlex.split(RUN_CMD) if RUN_CMD else RUN_CMD
+    VALIDATE_CMD = os.getenv('VALIDATE_CMD')
+    ANALYZE_CMD = os.getenv('ANALYZE_CMD')
+
+    parser = argparse.ArgumentParser(description='Run the commands with the sched.ini settings')
+    parser.add_argument('-c', '--optsched-cfg',
+                        required=OPTSCHEDCFG is None,
+                        default=OPTSCHEDCFG,
+                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDENV if it exists, else is required. The sched.ini is expected to be there')
+    parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
+    parser.add_argument('-L', '--labels', required=True,
+                        help='Comma separated labels to use for these runs. Must be equal to the number of --with flags')
+    parser.add_argument('--with', nargs='*', action='append', metavar='KEY=VALUE',
+                        help="The sched.ini settings to set for each run. Each run's settings should have a new --with flag.")
+    parser.add_argument(
+        'cmd', nargs='+', help='The command (with args) to run. Use - to default to the environment variable RUN_CMD.')
+    parser.add_argument('--append', action='store_true',
+                        help='Allow a <label>.log file to exist, appending to it if so')
+    parser.add_argument('--git-state', help='The path to a git repository to snapshot its state in our <outdir>.')
+
+    parser.add_argument('--validate', default=VALIDATE_CMD,
+                        help='The command (single string) to run after all runs to validate that the runs were correct. Defaults to the env variable VALIDATE_CMD. The output log files will be passed to the command, one additional arg for each run.')
+    parser.add_argument('--analyze', nargs='*', default=[ANALYZE_CMD],
+                        help='The commands (each a single string) to run after all runs to analyze the runs and produce output. Defaults to the single command from the env variable ANALYZE_CMD. The output log files will be passed to each command, one additional arg for each run.')
+    parser.add_argument('--analyze-files', nargs='*', default=[],
+                        help='The filenames to place the stdout of each analyze command.')
+
+    args = parser.parse_args()
+
+    main(
+        outdir=Path(args.outdir),
+        optsched_cfg=Path(args.optsched_cfg),
+        labels=args.labels,
+        withs=[runwith.parse_withs(with_) for with_ in getattr(args, 'with', [])],
+        cmd=args.cmd if args.cmd != '-' else RUN_CMD,
+        append_logs=args.append,
+        git_state=args.git_state,
+        validate_cmd=args.validate,
+        analyze_cmds=args.analyze,
+        analyze_files=args.analyze_files,
+    )

--- a/util/runners/multirun.py
+++ b/util/runners/multirun.py
@@ -65,6 +65,7 @@ if __name__ == '__main__':
     RUN_CMD = shlex.split(RUN_CMD) if RUN_CMD else RUN_CMD
     VALIDATE_CMD = os.getenv('VALIDATE_CMD')
     ANALYZE_CMD = os.getenv('ANALYZE_CMD')
+    RUNNER_GIT_REPO = os.getenv('RUNNER_GIT_REPO')
 
     parser = argparse.ArgumentParser(description='Run the commands with the sched.ini settings')
     parser.add_argument('-c', '--optsched-cfg',
@@ -80,7 +81,8 @@ if __name__ == '__main__':
         'cmd', nargs='+', help='The command (with args) to run. Use - to default to the environment variable RUN_CMD.')
     parser.add_argument('--append', action='store_true',
                         help='Allow a <label>.log file to exist, appending to it if so')
-    parser.add_argument('--git-state', help='The path to a git repository to snapshot its state in our <outdir>.')
+    parser.add_argument('--git-state', default=RUNNER_GIT_REPO,
+                        help='The path to a git repository to snapshot its state in our <outdir>. Defaults to the environment variable RUNNER_GIT_REPO if set. If not present, no git status will be generated.')
 
     parser.add_argument('--validate', default=VALIDATE_CMD,
                         help='The command (single string) to run after all runs to validate that the runs were correct. Defaults to the env variable VALIDATE_CMD. The output log files will be passed to the command, one additional arg for each run. To skip this, end the command with a bash comment #')

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
-import subprocess
 import argparse
 import os
 import re
-import shutil
 import shlex
+import shutil
+import subprocess
 from pathlib import Path
-from typing import Callable, Dict, List, Iterable, Optional
+from typing import Callable, Dict, Iterable, List, Optional
 
 # %% Setup
 
@@ -92,6 +92,8 @@ def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
         if code != 0:
             raise subprocess.CalledProcessError(code, cmd)
 
+    return logfile
+
 
 def get_git_state(git_state: Optional[str]) -> str:
     if not git_state:
@@ -117,7 +119,7 @@ def main(outdir: Path, optsched_cfg: Path, label: str, with_: Dict[str, str], cm
         edit_file(sched_ini, lambda f: edit_sched_ini(f, with_))
     save_sched_ini(outdir, sched_ini, label)
 
-    run_cmd(cmd, outdir, label, logmode='a' if append_logs else 'w')
+    return run_cmd(cmd, outdir, label, logmode='a' if append_logs else 'w')
 
 
 def parse_withs(withs: List[str]) -> Dict[str, str]:

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--optsched-cfg',
                         required=OPTSCHEDCFG is None,
                         default=OPTSCHEDCFG,
-                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDENV if it exists, else is required. The sched.ini is expected to be there')
+                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDCFG if it exists, else is required. The sched.ini is expected to be there')
     parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
     parser.add_argument('-L', '--label', required=True,
                         help='A label for this run, used in the output directory and for namespacing.')

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -87,7 +87,7 @@ def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
             f'File already exists. Either use a fresh output directory, or specify that we should append to the file: {logfile}')
 
     with open(outdir / f'{label}.log', logmode) as f:
-        proc = subprocess.Popen(cmd, stdout=f, stderr=f)
+        proc = subprocess.Popen(cmd, stdout=f, stderr=f, cwd=outdir)
         code = proc.wait()
         if code != 0:
             raise subprocess.CalledProcessError(code, cmd)

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -88,7 +88,7 @@ def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
             f'File already exists. Either use a fresh output directory, or specify that we should append to the file: {logfile}')
 
     with open(outdir / f'{label}.log', logmode) as f:
-        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, cwd=outdir, check=True)
+        subprocess.run(shlex.join(cmd), stdout=f, stderr=subprocess.STDOUT, cwd=outdir, check=True, shell=True)
 
     return logfile
 

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -129,6 +129,7 @@ if __name__ == '__main__':
     OPTSCHEDCFG = os.getenv('OPTSCHEDCFG')
     RUN_CMD = os.getenv('RUN_CMD')
     RUN_CMD = shlex.split(RUN_CMD) if RUN_CMD else RUN_CMD
+    RUNNER_GIT_REPO = os.getenv('RUNNER_GIT_REPO')
 
     parser = argparse.ArgumentParser(description='Run the commands with the sched.ini settings')
     parser.add_argument('-c', '--optsched-cfg',
@@ -143,7 +144,8 @@ if __name__ == '__main__':
         'cmd', nargs='+', help='The command (with args) to run. Use - to default to the environment variable RUN_CMD.')
     parser.add_argument('--append', action='store_true',
                         help='Allow a <label>.log file to exist, appending to it if so')
-    parser.add_argument('--git-state', help='The path to a git repository to snapshot its state in our <outdir>.')
+    parser.add_argument('--git-state', default=RUNNER_GIT_REPO,
+                        help='The path to a git repository to snapshot its state in our <outdir>. Defaults to the environment variable RUNNER_GIT_REPO if set. If not present, no git status will be generated.')
 
     args = parser.parse_args()
 

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -14,7 +14,7 @@ from typing import Callable, Dict, Iterable, List, Optional
 class InvalidSchedIniSettingError(Exception):
     def __init__(self, message: str, keys: List[str]):
         self.keys = keys
-        super().__init__(f'{message}: {keys=}')
+        super().__init__(f'{message}: keys={keys}')
 
 
 class LogFileExistsError(FileExistsError):
@@ -25,7 +25,7 @@ class GitStateChangedError(Exception):
     def __init__(self, message: str, old: Path, new: Path):
         self.old = old
         self.new = new
-        super().__init__(f'{message}: {old=}, {new=}')
+        super().__init__(f'{message}: old={old}, new={new}')
 
 
 def setup_outdir(outdir: Path, optsched_cfg: Path, keys: Iterable[str], git_state: str):

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import subprocess
+import argparse
+import os
+import re
+import shutil
+import shlex
+from pathlib import Path
+from typing import Callable, Dict, List, Iterable, Optional
+
+# %% Setup
+
+
+class InvalidSchedIniSettingError(Exception):
+    def __init__(self, message: str, keys: List[str]):
+        self.keys = keys
+        super().__init__(f'{message}: {keys=}')
+
+
+class LogFileExistsError(FileExistsError):
+    pass
+
+
+class GitStateChangedError(Exception):
+    def __init__(self, message: str, old: Path, new: Path):
+        self.old = old
+        self.new = new
+        super().__init__(f'{message}: {old=}, {new=}')
+
+
+def setup_outdir(outdir: Path, optsched_cfg: Path, keys: Iterable[str], git_state: str):
+    outdir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(optsched_cfg, outdir / 'optsched-cfg', dirs_exist_ok=True)
+
+    if git_state:
+        p: Path = outdir / 'git.status'
+        p2: Path = outdir / 'git.status.2'
+        with open(p2, 'w') as f:
+            f.write(git_state)
+
+        if p.exists():
+            with open(p, 'r') as f:
+                if f.read() != git_state:
+                    raise GitStateChangedError(
+                        'Git state changed between runs! If this was intended, delete the old git.status file. See state files', p, p2)
+            os.remove(p)
+
+        p2.rename(p)
+
+    for key in keys:
+        p: Path = outdir / key
+        p.touch()
+
+
+def edit_sched_ini(sched_ini: str, with_: Dict[str, str]) -> str:
+    missing_keys = []
+
+    for key, value in with_.items():
+        kv_re = re.compile(rf'(?<=^{key} ).*$', flags=re.MULTILINE)
+        if not kv_re.search(sched_ini):
+            missing_keys.append(key)
+        sched_ini = kv_re.sub(value, sched_ini)
+
+    if missing_keys:
+        raise InvalidSchedIniSettingError('Unable to find these keys in the sched.ini file', missing_keys)
+
+    return sched_ini
+
+
+def save_sched_ini(outdir: Path, sched_ini: Path, label: str):
+    shutil.copy(sched_ini, outdir / f'{label}.sched.ini')
+
+
+def edit_file(path: Path, edit: Callable[[str], str]):
+    # assert path.is_file()
+    with open(path, 'r+') as f:
+        contents = edit(f.read())
+        f.seek(0)
+        f.truncate()
+        f.write(contents)
+
+
+def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
+    logfile = outdir / f'{label}.log'
+    if logfile.exists() and logmode == 'w':
+        raise LogFileExistsError(
+            f'File already exists. Either use a fresh output directory, or specify that we should append to the file: {logfile}')
+
+    with open(outdir / f'{label}.log', logmode) as f:
+        proc = subprocess.Popen(cmd, stdout=f, stderr=f)
+        code = proc.wait()
+        if code != 0:
+            raise subprocess.CalledProcessError(code, cmd)
+
+
+def get_git_state(git_state: Optional[str]) -> str:
+    if not git_state:
+        return ''
+
+    git_repo = str(Path(git_state).resolve())
+    commit = subprocess.run(['git', '-C', git_repo, 'log', '-n1'], encoding='utf-8', capture_output=True, check=True)
+    status = subprocess.run(['git', '-C', git_repo, 'status'], encoding='utf-8', capture_output=True, check=True)
+    diff = subprocess.run(['git', '-C', git_repo, 'diff'], encoding='utf-8', capture_output=True, check=True)
+
+    return f'{git_repo}\n{commit.stdout}\n\n{status.stdout}\n\n{diff.stdout}'
+
+
+def main(outdir: Path, optsched_cfg: Path, label: str, with_: Dict[str, str], cmd: List[str], append_logs: bool = False, git_state: Optional[str] = None):
+    outdir = outdir.resolve()
+    optsched_cfg = optsched_cfg.resolve()
+
+    git_state = get_git_state(git_state)
+    setup_outdir(outdir, optsched_cfg, with_.keys(), git_state)
+
+    sched_ini = optsched_cfg / 'sched.ini'
+    if with_:
+        edit_file(sched_ini, lambda f: edit_sched_ini(f, with_))
+    save_sched_ini(outdir, sched_ini, label)
+
+    run_cmd(cmd, outdir, label, logmode='a' if append_logs else 'w')
+
+
+def parse_withs(withs: List[str]) -> Dict[str, str]:
+    return dict(with_.split('=', maxsplit=1) for with_ in withs)
+
+
+# %% Main
+if __name__ == '__main__':
+    OPTSCHEDCFG = os.getenv('OPTSCHEDCFG')
+    RUN_CMD = os.getenv('RUN_CMD')
+    RUN_CMD = shlex.split(RUN_CMD) if RUN_CMD else RUN_CMD
+
+    parser = argparse.ArgumentParser(description='Run the commands with the sched.ini settings')
+    parser.add_argument('-c', '--optsched-cfg',
+                        required=OPTSCHEDCFG is None,
+                        default=OPTSCHEDCFG,
+                        help='The path to the optsched config to use. Defaults to the env variable OPTSCHEDENV if it exists, else is required. The sched.ini is expected to be there')
+    parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
+    parser.add_argument('-L', '--label', required=True,
+                        help='A label for this run, used in the output directory and for namespacing.')
+    parser.add_argument('--with', nargs='*', metavar='KEY=VALUE', help='The sched.ini settings to set.')
+    parser.add_argument(
+        'cmd', nargs='+', help='The command (with args) to run. Use - to default to the environment variable RUN_CMD.')
+    parser.add_argument('--append', action='store_true',
+                        help='Allow a <label>.log file to exist, appending to it if so')
+    parser.add_argument('--git-state', help='The path to a git repository to snapshot its state in our <outdir>.')
+
+    args = parser.parse_args()
+
+    main(
+        outdir=Path(args.outdir),
+        optsched_cfg=Path(args.optsched_cfg),
+        label=args.label,
+        with_=parse_withs(getattr(args, 'with', [])),
+        cmd=args.cmd if args.cmd != '-' else RUN_CMD,
+        append_logs=args.append,
+        git_state=args.git_state,
+    )

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -30,7 +30,8 @@ class GitStateChangedError(Exception):
 
 def setup_outdir(outdir: Path, optsched_cfg: Path, keys: Iterable[str], git_state: str):
     outdir.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(optsched_cfg, outdir / 'optsched-cfg', dirs_exist_ok=True)
+    if not (outdir / 'optsched-cfg').exists():
+        shutil.copytree(optsched_cfg, outdir / 'optsched-cfg')
 
     if git_state:
         p: Path = outdir / 'git.status'

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -153,7 +153,7 @@ if __name__ == '__main__':
         outdir=Path(args.outdir),
         optsched_cfg=Path(args.optsched_cfg),
         label=args.label,
-        with_=parse_withs(getattr(args, 'with', [])),
+        with_=parse_withs(getattr(args, 'with') if getattr(args, 'with') is not None else []),
         cmd=args.cmd if args.cmd != '-' else RUN_CMD,
         append_logs=args.append,
         git_state=args.git_state,

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -88,10 +88,7 @@ def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
             f'File already exists. Either use a fresh output directory, or specify that we should append to the file: {logfile}')
 
     with open(outdir / f'{label}.log', logmode) as f:
-        proc = subprocess.Popen(cmd, stdout=f, stderr=f, cwd=outdir)
-        code = proc.wait()
-        if code != 0:
-            raise subprocess.CalledProcessError(code, cmd)
+        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, cwd=outdir, check=True)
 
     return logfile
 

--- a/util/runners/runwith.py
+++ b/util/runners/runwith.py
@@ -88,7 +88,7 @@ def run_cmd(cmd: List[str], outdir: Path, label: str, logmode='w'):
             f'File already exists. Either use a fresh output directory, or specify that we should append to the file: {logfile}')
 
     with open(outdir / f'{label}.log', logmode) as f:
-        subprocess.run(shlex.join(cmd), stdout=f, stderr=subprocess.STDOUT, cwd=outdir, check=True, shell=True)
+        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT, cwd=outdir, check=True)
 
     return logfile
 

--- a/util/runners/shocrunner.py
+++ b/util/runners/shocrunner.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from typing import Dict
+
+
+def main(shocdriver: Path, outdir: Path, shoc_args: Dict[str, str]):
+    outdir = outdir.resolve()
+    if not outdir.exists():
+        outdir.mkdir()
+
+    cmd = [str(shocdriver), '-opencl']
+    for k, v in shoc_args.items():
+        cmd.append(k)
+        cmd.append(v)
+
+    subprocess.run(cmd + ['-benchmark', 'FFT'], check=True, cwd=outdir)
+    subprocess.run(cmd + ['-benchmark', 'GEMM'], check=True, cwd=outdir)
+    subprocess.run(cmd + ['-benchmark', 'MD'], check=True, cwd=outdir)
+    subprocess.run(cmd + ['-benchmark', 'Sort'], check=True, cwd=outdir)
+    subprocess.run(cmd + ['-benchmark', 'Spmv'], check=True, cwd=outdir)
+    subprocess.run(cmd + ['-benchmark', 'Stencil2D'], check=True, cwd=outdir)
+
+
+if __name__ == '__main__':
+    SHOCDRIVER = os.getenv('SHOCDRIVER')
+    parser = argparse.ArgumentParser(description='Run the SHOC benchmarks')
+    parser.add_argument('--shocdriver', default=SHOCDRIVER, required=SHOCDRIVER is None,
+                        help='The path the the shocdriver executable')
+    parser.add_argument('-o', '--outdir', required=True, help='The path to place the output files at')
+    parser.add_argument('-s', '--shoc-problem-size', default='4',
+                        help='The SHOC problem size, passed on to the shocdriver')
+
+    args = parser.parse_args()
+
+    main(shocdriver=args.shocdriver, outdir=args.outdir, shoc_args={'-s': args.shoc_problem_size})


### PR DESCRIPTION
I've updated my benchmark running scripts and figured I might as well PR them.

Sample:

```bash
export SHOCDRIVER="/path/to/shoc/build/bin/shocdriver"
export OPTSCHEDCFG="/path/to/optsched-cfg"
export VALIDATE_CMD="~/scripts/validate"
export ANALYZE_CMD="~/scripts/analyze"
export RUNNER_GIT_REPO="/path/to/OptSched"

# ~/scripts/validate
#!/usr/bin/env bash
# This is a modified validation-test.py script that I use
python3 ~/OptSched/util/misc/validation-test.py --benchsuite=$BENCHSUITE no.*/ yes.*/ | tee validation.txt

# ~/scripts/analyze
#!/usr/bin/env bash
~/OptSched/util/gt_analysis/gt_cmp.py --benchsuite=$BENCHSUITE no.*/ yes.*/ | tee nodesx.csv
~/OptSched/util/gt_analysis/gt_cmp.py --benchsuite=$BENCHSUITE --pass-num=1 no.*/ yes.*/ | tee nodesx1.csv
~/OptSched/util/gt_analysis/gt_cmp.py --benchsuite=$BENCHSUITE --pass-num=2 no.*/ yes.*/ | tee nodesx2.csv
```

The actual run command (`~/runners` is a symlink to `~/OptSched/util/runners`):

`
BENCHSUITE=plaidml python3.8 ~/runners/multirun.py -o ~/local-results/output/$(~/runners/datename) -L yes,no --with STATIC_NODE_SUPERIORITY=YES 2ND_PASS_ILP_NODE_SUPERIORITY_PRESERVING_OCCUPANCY=YES --with STATIC_NODE_SUPERIORITY=NO 2ND_PASS_ILP_NODE_SUPERIORITY_PRESERVING_OCCUPANCY=NO -- ~/run-plaidbench.py {{label}}.logs -b xception
`

This does two runs of the `~/run-plaidbench.py` command, one with the first `--with`'s settings, and one with the second `--with`'s settings.

----

It does require Python 3.8; Python 3.6 doesn't have `capture_output` on the `subprocess.run(...)` command.

I'll also probably rebase this to simplify the git history if we do want to merge this.