### PR TITLE
Support newer LLVM versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build
-/.vscode
+build
+.vscode
 __pycache__
 *.pyc

--- a/include/opt-sched/Scheduler/lnkd_lst.h
+++ b/include/opt-sched/Scheduler/lnkd_lst.h
@@ -178,9 +178,9 @@ template <class EntryType>
 std::unique_ptr<EntryAllocator<typename EntryType::value_type>>
 makeDynamicOrArenaAllocator(int MaxSize) {
   if (MaxSize == INVALID_VALUE)
-    return llvm::make_unique<DynamicEntryAllocator<EntryType>>();
+    return std::make_unique<DynamicEntryAllocator<EntryType>>();
   else
-    return llvm::make_unique<ArenaEntryAllocator<EntryType>>(MaxSize);
+    return std::make_unique<ArenaEntryAllocator<EntryType>>(MaxSize);
 }
 
 template <class T> class LinkedList;

--- a/lib/Scheduler/aco.cpp
+++ b/lib/Scheduler/aco.cpp
@@ -283,7 +283,7 @@ std::unique_ptr<InstSchedule>
 ACOScheduler::FindOneSchedule(InstCount TargetRPCost) {
   SchedInstruction *lastInst = NULL;
   std::unique_ptr<InstSchedule> schedule =
-      llvm::make_unique<InstSchedule>(machMdl_, dataDepGraph_, true);
+      std::make_unique<InstSchedule>(machMdl_, dataDepGraph_, true);
   InstCount maxPriority = rdyLst_->MaxPriority();
   if (maxPriority == 0)
     maxPriority = 1; // divide by 0 is bad
@@ -671,7 +671,7 @@ void PrintSchedule(InstSchedule *schedule) {
 void ACOScheduler::setInitialSched(InstSchedule *Sched) {
   if (Sched) {
     InitialSchedule =
-        llvm::make_unique<InstSchedule>(machMdl_, dataDepGraph_, VrfySched_);
+        std::make_unique<InstSchedule>(machMdl_, dataDepGraph_, VrfySched_);
     InitialSchedule->Copy(Sched);
   }
 }

--- a/lib/Scheduler/bb_spill.cpp
+++ b/lib/Scheduler/bb_spill.cpp
@@ -199,7 +199,7 @@ static InstCount ComputeSLILStaticLowerBound(int64_t regTypeCnt_,
     // between the recursive successor list of this instruction and the
     // recursive predecessors of the dependent instruction.
     auto recSuccBV = inst->GetRcrsvNghbrBitVector(DIR_FRWRD);
-    for (Register *def : inst->GetDefs()) {
+    for (opt_sched::Register *def : inst->GetDefs()) {
       for (const auto &dependentInst : def->GetUseList()) {
         auto recPredBV = const_cast<SchedInstruction *>(dependentInst)
                              ->GetRcrsvNghbrBitVector(DIR_BKWRD);
@@ -225,14 +225,15 @@ static InstCount ComputeSLILStaticLowerBound(int64_t regTypeCnt_,
   // based on the instructions that use more than one register (defined by
   // different instructions).
   int commonUseLowerBound = closureLowerBound;
-  std::vector<std::pair<const SchedInstruction *, Register *>> usedInsts;
+  std::vector<std::pair<const SchedInstruction *, opt_sched::Register *>>
+      usedInsts;
   for (int i = 0; i < dataDepGraph_->GetInstCnt(); ++i) {
     const auto &inst = dataDepGraph_->GetInstByIndx(i);
 
     // Get a list of instructions that define the registers, in array form.
     usedInsts.clear();
     llvm::transform(inst->GetUses(), std::back_inserter(usedInsts),
-                    [&](Register *reg) {
+                    [&](opt_sched::Register *reg) {
                       assert(reg->GetDefList().size() == 1 &&
                              "Number of defs for register is not 1!");
                       return std::make_pair(*(reg->GetDefList().begin()), reg);
@@ -477,7 +478,7 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
 #endif
 
   // Update Live regs after uses
-  for (Register *use : inst->GetUses()) {
+  for (opt_sched::Register *use : inst->GetUses()) {
     regType = use->GetType();
     regNum = use->GetNum();
     physRegNum = use->GetPhysicalNumber();
@@ -519,7 +520,7 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
   }
 
   // Update Live regs after defs
-  for (Register *def : inst->GetDefs()) {
+  for (opt_sched::Register *def : inst->GetDefs()) {
     regType = def->GetType();
     regNum = def->GetNum();
     physRegNum = def->GetPhysicalNumber();
@@ -575,7 +576,7 @@ void BBWithSpill::UpdateSpillInfoForSchdul_(SchedInstruction *inst,
       sumOfLiveIntervalLengths_[i] += liveRegs_[i].GetOneCnt();
       for (int j = 0; j < liveRegs_[i].GetSize(); ++j) {
         if (liveRegs_[i].GetBit(j)) {
-          const Register *reg = regFiles_[i].GetReg(j);
+          const opt_sched::Register *reg = regFiles_[i].GetReg(j);
           if (!reg->IsInInterval(inst) && !reg->IsInPossibleInterval(inst)) {
             ++dynamicSlilLowerBound_;
           }
@@ -636,7 +637,7 @@ void BBWithSpill::UpdateSpillInfoForUnSchdul_(SchedInstruction *inst) {
     for (int i = 0; i < regTypeCnt_; ++i) {
       for (int j = 0; j < liveRegs_[i].GetSize(); ++j) {
         if (liveRegs_[i].GetBit(j)) {
-          const Register *reg = regFiles_[i].GetReg(j);
+          const opt_sched::Register *reg = regFiles_[i].GetReg(j);
           sumOfLiveIntervalLengths_[i]--;
           if (!reg->IsInInterval(inst) && !reg->IsInPossibleInterval(inst)) {
             --dynamicSlilLowerBound_;
@@ -649,7 +650,7 @@ void BBWithSpill::UpdateSpillInfoForUnSchdul_(SchedInstruction *inst) {
   }
 
   // Update Live regs
-  for (Register *def : inst->GetDefs()) {
+  for (opt_sched::Register *def : inst->GetDefs()) {
     regType = def->GetType();
     regNum = def->GetNum();
     physRegNum = def->GetPhysicalNumber();
@@ -674,7 +675,7 @@ void BBWithSpill::UpdateSpillInfoForUnSchdul_(SchedInstruction *inst) {
     //}
   }
 
-  for (Register *use : inst->GetUses()) {
+  for (opt_sched::Register *use : inst->GetUses()) {
     regType = use->GetType();
     regNum = use->GetNum();
     physRegNum = use->GetPhysicalNumber();
@@ -1091,8 +1092,8 @@ bool BBWithSpill::ChkInstLglty(SchedInstruction *inst) {
   /*
   int16_t regType;
   int defCnt, physRegNum;
-  Register **defs;
-  Register *def, *liveDef;
+  opt_sched::Register **defs;
+  opt_sched::Register *def, *liveDef;
 
 #ifdef IS_DEBUG_CHECK
   Logger::Info("Checking inst %d %s", inst->GetNum(), inst->GetOpCode());
@@ -1111,7 +1112,7 @@ bool BBWithSpill::ChkInstLglty(SchedInstruction *inst) {
   }
 
   // Update Live regs
-  for (Register *def : inst->GetDefs()) {
+  for (opt_sched::Register *def : inst->GetDefs()) {
     regType = def->GetType();
     physRegNum = def->GetPhysicalNumber();
 

--- a/lib/Scheduler/data_dep.cpp
+++ b/lib/Scheduler/data_dep.cpp
@@ -197,7 +197,7 @@ DataDepGraph::DataDepGraph(MachineModel *machMdl, LATENCY_PRECISION ltncyPrcsn)
   entryInstCnt_ = 0;
   exitInstCnt_ = 0;
 
-  RegFiles = llvm::make_unique<RegisterFile[]>(machMdl_->GetRegTypeCnt());
+  RegFiles = std::make_unique<RegisterFile[]>(machMdl_->GetRegTypeCnt());
 }
 
 DataDepGraph::~DataDepGraph() {

--- a/lib/Scheduler/graph_trans_ilp.cpp
+++ b/lib/Scheduler/graph_trans_ilp.cpp
@@ -158,7 +158,7 @@ StaticNodeSupILPTrans::DataAlloc::DataAlloc(DataDepGraph &DDG)
       SuperiorNodesList(
           createSuperiorNodesList(wrapAs2D(SuperiorArray, DDG.GetNodeCnt()))),
       AddedEdges(), Stats(),
-      Data_(llvm::make_unique<Data>(Data{
+      Data_(std::make_unique<Data>(Data{
           DDG,
           wrapAs2D(this->DistanceTable, DDG.GetNodeCnt()),
           wrapAs2D(this->SuperiorArray, DDG.GetNodeCnt()),

--- a/lib/Scheduler/register.cpp
+++ b/lib/Scheduler/register.cpp
@@ -165,7 +165,7 @@ void RegisterFile::ResetCrntLngths() {
 
 Register *RegisterFile::getNext() {
   size_t RegNum = Regs.size();
-  auto Reg = llvm::make_unique<Register>();
+  auto Reg = std::make_unique<Register>();
   Reg->SetType(regType_);
   Reg->SetNum(RegNum);
   Regs.push_back(std::move(Reg));
@@ -178,7 +178,7 @@ void RegisterFile::SetRegCnt(int regCnt) {
 
   Regs.resize(regCnt);
   for (int i = 0; i < getCount(); i++) {
-    auto Reg = llvm::make_unique<Register>();
+    auto Reg = std::make_unique<Register>();
     Reg->SetType(regType_);
     Reg->SetNum(i);
     Regs[i] = std::move(Reg);

--- a/lib/Scheduler/sched_region.cpp
+++ b/lib/Scheduler/sched_region.cpp
@@ -146,7 +146,7 @@ static bool isBbEnabled(Config &schedIni, Milliseconds rgnTimeout) {
 
 static void dumpDDG(DataDepGraph *DDG, llvm::StringRef DDGDumpPath,
                     llvm::StringRef Suffix = "") {
-  std::string Path = DDGDumpPath;
+  std::string Path(DDGDumpPath);
   Path += DDG->GetDagID();
 
   if (!Suffix.empty()) {

--- a/lib/Wrapper/AMDGPU/GCNOptSched.cpp
+++ b/lib/Wrapper/AMDGPU/GCNOptSched.cpp
@@ -22,7 +22,7 @@ static cl::opt<bool>
 
 static ScheduleDAGInstrs *createOptSchedGCN(MachineSchedContext *C) {
   ScheduleDAGMILive *DAG = new ScheduleDAGOptSchedGCN(
-      C, llvm::make_unique<GCNMaxOccupancySchedStrategy>(C));
+      C, std::make_unique<GCNMaxOccupancySchedStrategy>(C));
   DAG->addMutation(createLoadClusterDAGMutation(DAG->TII, DAG->TRI));
   DAG->addMutation(createStoreClusterDAGMutation(DAG->TII, DAG->TRI));
   return DAG;

--- a/lib/Wrapper/AMDGPU/OptSchedDDGWrapperGCN.cpp
+++ b/lib/Wrapper/AMDGPU/OptSchedDDGWrapperGCN.cpp
@@ -29,7 +29,7 @@ namespace {
 
 std::unique_ptr<SubRegSet>
 createSubRegSet(unsigned Reg, const MachineRegisterInfo &MRI, int16_t Type) {
-  return llvm::make_unique<SubRegSet>(
+  return std::make_unique<SubRegSet>(
       MRI.getMaxLaneMaskForVReg(Reg).getNumLanes(), Type);
 }
 

--- a/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
+++ b/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
@@ -66,15 +66,15 @@ class OptSchedGCNTarget : public OptSchedTarget {
 public:
   std::unique_ptr<OptSchedMachineModel>
   createMachineModel(const char *ConfigPath) override {
-    return llvm::make_unique<OptSchedMachineModel>(ConfigPath);
+    return std::make_unique<OptSchedMachineModel>(ConfigPath);
   }
 
   std::unique_ptr<OptSchedDDGWrapperBase>
   createDDGWrapper(llvm::MachineSchedContext *Context, ScheduleDAGOptSched *DAG,
                    OptSchedMachineModel *MM, LATENCY_PRECISION LatencyPrecision,
                    const std::string &RegionID) override {
-    return llvm::make_unique<OptSchedDDGWrapperGCN>(Context, DAG, MM,
-                                                    LatencyPrecision, RegionID);
+    return std::make_unique<OptSchedDDGWrapperGCN>(Context, DAG, MM,
+                                                   LatencyPrecision, RegionID);
   }
 
   void initRegion(llvm::ScheduleDAGInstrs *DAG, MachineModel *MM_) override;
@@ -113,7 +113,7 @@ private:
 };
 
 std::unique_ptr<OptSchedTarget> createOptSchedGCNTarget() {
-  return llvm::make_unique<OptSchedGCNTarget>();
+  return std::make_unique<OptSchedGCNTarget>();
 }
 
 } // end anonymous namespace

--- a/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
+++ b/lib/Wrapper/OptSchedDDGWrapperBasic.cpp
@@ -449,7 +449,7 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
     int16_t Latency;
     if (ltncyPrcsn_ == LTP_PRECISE) { // get latency from the machine model
       const auto &InstName = DAG->TII->getName(instr->getOpcode());
-      const auto &InstType = MM->GetInstTypeByName(InstName);
+      const auto &InstType = MM->GetInstTypeByName(std::string(InstName));
       Latency = MM->GetLatency(InstType, DepType);
     } else if (ltncyPrcsn_ == LTP_ROUGH) { // rough latency = llvm latency
       Latency = I->getLatency();
@@ -457,9 +457,11 @@ void OptSchedDDGWrapperBasic::convertEdges(const SUnit &SU,
       // by the specified divisor
       if (DAG->reducedLatencyPassStarted() &&
           Latency > DAG->getLatencyTarget()) {
-        const string &InstFromName = DAG->TII->getName(instr->getOpcode());
+        const string &InstFromName =
+            std::string(DAG->TII->getName(instr->getOpcode()));
         const MachineInstr *ToInstr = I->getSUnit()->getInstr();
-        const string &InstToName = DAG->TII->getName(ToInstr->getOpcode());
+        const string &InstToName =
+            std::string(DAG->TII->getName(ToInstr->getOpcode()));
         int16_t OldLatency = Latency;
         Latency /= DAG->getLatencyDivisor();
         if (Latency < DAG->getLatencyMinimun())
@@ -484,7 +486,7 @@ void OptSchedDDGWrapperBasic::convertSUnit(const SUnit &SU) {
     return;
 
   const MachineInstr *MI = SU.getInstr();
-  InstName = DAG->TII->getName(MI->getOpcode());
+  InstName = std::string(DAG->TII->getName(MI->getOpcode()));
 
   // Search in the machine model for an instType with this OpCode name
   InstType = MM->GetInstTypeByName(InstName.c_str());

--- a/lib/Wrapper/OptSchedGenericTarget.cpp
+++ b/lib/Wrapper/OptSchedGenericTarget.cpp
@@ -24,14 +24,14 @@ class OptSchedGenericTarget : public OptSchedTarget {
 public:
   std::unique_ptr<OptSchedMachineModel>
   createMachineModel(const char *ConfigPath) override {
-    return llvm::make_unique<OptSchedMachineModel>(ConfigPath);
+    return std::make_unique<OptSchedMachineModel>(ConfigPath);
   }
 
   std::unique_ptr<OptSchedDDGWrapperBase>
   createDDGWrapper(llvm::MachineSchedContext *Context, ScheduleDAGOptSched *DAG,
                    OptSchedMachineModel *MM, LATENCY_PRECISION LatencyPrecision,
                    const std::string &RegionID) override {
-    return llvm::make_unique<OptSchedDDGWrapperBasic>(
+    return std::make_unique<OptSchedDDGWrapperBasic>(
         Context, DAG, MM, LatencyPrecision, RegionID);
   }
 
@@ -57,7 +57,7 @@ namespace llvm {
 namespace opt_sched {
 
 std::unique_ptr<OptSchedTarget> createOptSchedGenericTarget() {
-  return llvm::make_unique<OptSchedGenericTarget>();
+  return std::make_unique<OptSchedGenericTarget>();
 }
 
 OptSchedTargetRegistry

--- a/lib/Wrapper/OptSchedMachineWrapper.cpp
+++ b/lib/Wrapper/OptSchedMachineWrapper.cpp
@@ -45,13 +45,13 @@ void dumpInstType(InstTypeInfo &instType, MachineModel *mm) {
 std::unique_ptr<MachineModelGenerator>
 createCortexA7MMGenerator(const llvm::ScheduleDAGInstrs *dag,
                           MachineModel *mm) {
-  return make_unique<CortexA7MMGenerator>(dag, mm);
+  return std::make_unique<CortexA7MMGenerator>(dag, mm);
 }
 
 std::unique_ptr<MachineModelGenerator>
 createCortexA53MMGenerator(const llvm::ScheduleDAGInstrs *dag,
                            MachineModel *mm) {
-  return make_unique<CortexA53MMGenerator>(dag, mm);
+  return std::make_unique<CortexA53MMGenerator>(dag, mm);
 }
 
 } // end anonymous namespace
@@ -183,7 +183,7 @@ IssueType CortexA7MMGenerator::generateIssueType(const InstrStage *E) const {
 
 InstType CortexA7MMGenerator::generateInstrType(const MachineInstr *instr) {
   // Search in the machine model for an instType with this OpCode
-  const std::string instrName = DAG->TII->getName(instr->getOpcode());
+  const std::string instrName(DAG->TII->getName(instr->getOpcode()));
   const InstType InstType = MM->GetInstTypeByName(instrName);
 
   // If the machine model does not have instType with this OpCode name,
@@ -242,7 +242,7 @@ void CortexA53MMGenerator::generateProcessorData(std::string *mdlName_,
 InstType
 CortexA53MMGenerator::generateInstrType(const llvm::MachineInstr *instr) {
   // Search in the machine model for an instType with this OpCode
-  const std::string InstrName = DAG->TII->getName(instr->getOpcode());
+  const std::string InstrName(DAG->TII->getName(instr->getOpcode()));
   const InstType InstrType = MM->GetInstTypeByName(InstrName);
 
   // If the machine model does not have instType with this OpCode name,

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -32,6 +32,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
 #include <algorithm>
 #include <chrono>
 #include <string>
@@ -68,7 +69,7 @@ static constexpr const char *DEFAULT_CFGMM_FNAME = "/machine_model.cfg";
 // Create OptSched ScheduleDAG.
 static ScheduleDAGInstrs *createOptSched(MachineSchedContext *C) {
   ScheduleDAGMILive *DAG =
-      new ScheduleDAGOptSched(C, llvm::make_unique<GenericScheduler>(C));
+      new ScheduleDAGOptSched(C, std::make_unique<GenericScheduler>(C));
   DAG->addMutation(createCopyConstrainDAGMutation(DAG->TII, DAG->TRI));
   // README: if you need the x86 mutations uncomment the next line.
   // addMutation(createX86MacroFusionDAGMutation());
@@ -178,7 +179,7 @@ static SchedulerType parseListSchedType() {
 
 static std::unique_ptr<GraphTrans>
 createStaticNodeSupTrans(DataDepGraph *DataDepGraph, bool IsMultiPass = false) {
-  return llvm::make_unique<StaticNodeSupTrans>(DataDepGraph, IsMultiPass);
+  return std::make_unique<StaticNodeSupTrans>(DataDepGraph, IsMultiPass);
 }
 
 void ScheduleDAGOptSched::addGraphTransformations(
@@ -196,7 +197,7 @@ void ScheduleDAGOptSched::addGraphTransformations(
 
   if (ILPStaticNodeSup) {
     GraphTransformations->push_back(
-        llvm::make_unique<StaticNodeSupILPTrans>(BDDG));
+        std::make_unique<StaticNodeSupILPTrans>(BDDG));
   }
 }
 
@@ -424,7 +425,7 @@ void ScheduleDAGOptSched::schedule() {
   addGraphTransformations(BDDG);
 
   // create region
-  auto region = llvm::make_unique<BBWithSpill>(
+  auto region = std::make_unique<BBWithSpill>(
       OST.get(), static_cast<DataDepGraph *>(DDG.get()), 0, HistTableHashBits,
       LowerBoundAlgorithm, HeuristicPriorities, EnumPriorities, VerifySchedule,
       PruningStrategy, SchedForRPOnly, EnumStalls, SCW, SCF, HeurSchedType);
@@ -652,7 +653,7 @@ bool ScheduleDAGOptSched::isOptSchedEnabled() const {
     return true;
   } else if (optSchedOption == "HOT_ONLY") {
     // get the name of the function this scheduler was created for
-    std::string functionName = C->MF->getFunction().getName();
+    std::string functionName(C->MF->getFunction().getName());
     // check the list of hot functions for the name of the current function
     return HotFunctions.GetBool(functionName, false);
   } else if (optSchedOption == "NO") {
@@ -761,7 +762,7 @@ bool ScheduleDAGOptSched::shouldPrintSpills() const {
   } else if (printSpills == "NO") {
     return false;
   } else if (printSpills == "HOT_ONLY") {
-    std::string functionName = C->MF->getFunction().getName();
+    std::string functionName(C->MF->getFunction().getName());
     return HotFunctions.GetBool(functionName, false);
   }
 


### PR DESCRIPTION
Supports up to LLVM 13.
 - `llvm::make_unique` -> `std::make_unique`.
 - `Register`, referring to `llvm::opt_sched::Register`, is now explicit
   in most places.
 - `llvm::StringRef`'s conversion to `std::string` is now explicit. This
   exposes some inefficiencies with what we're doing.

----

I want to add some GitHub CI checks for other LLVM versions before merging this.