### PR TITLE
Fix master bug

### DIFF
--- a/include/opt-sched/Scheduler/machine_model.h
+++ b/include/opt-sched/Scheduler/machine_model.h
@@ -189,6 +189,8 @@ protected:
   std::vector<RegTypeInfo> registerTypes_;
   // A vector of issue types with their names and slot counts.
   std::vector<IssueTypeInfo> issueTypes_;
+
+  void parseBuffer(SpecsBuffer &buf);
 };
 
 } // namespace opt_sched

--- a/lib/Scheduler/machine_model.cpp
+++ b/lib/Scheduler/machine_model.cpp
@@ -14,37 +14,7 @@ using namespace llvm::opt_sched;
 using std::string;
 using std::vector;
 
-MachineModel::MachineModel(const std::string &modelFile) {
-  SpecsBuffer buf;
-  buf.Load(modelFile.c_str());
-
-  char buffer[MAX_NAMESIZE];
-
-  buf.ReadSpec("MODEL_NAME:", buffer);
-  mdlName_ = buffer;
-
-  issueRate_ = buf.ReadIntSpec("ISSUE_RATE:");
-
-  int numIssueTypes = buf.ReadIntSpec("ISSUE_TYPE_COUNT:");
-
-  issueTypes_.resize(numIssueTypes > 0 ? numIssueTypes : 1);
-  if (numIssueTypes > 0) {
-    for (size_t j = 0; j < issueTypes_.size(); j++) {
-      int pieceCnt;
-      char *strngs[INBUF_MAX_PIECES_PERLINE];
-      int lngths[INBUF_MAX_PIECES_PERLINE];
-      buf.GetNxtVldLine(pieceCnt, strngs, lngths);
-
-      if (pieceCnt != 2)
-        llvm::report_fatal_error("Invalid issue type spec", false);
-
-      issueTypes_[j].name = strngs[0];
-      issueTypes_[j].slotsCount = atoi(strngs[1]);
-    }
-  }
-}
-
-MachineModel::MachineModel(SpecsBuffer &buf) {
+void MachineModel::parseBuffer(SpecsBuffer &buf) {
   char buffer[MAX_NAMESIZE];
 
   buf.ReadSpec("MODEL_NAME:", buffer);
@@ -115,6 +85,14 @@ MachineModel::MachineModel(SpecsBuffer &buf) {
     it->sprtd = buf.ReadFlagSpec("SUPPORTED:", true);
   }
 }
+
+MachineModel::MachineModel(const std::string &modelFile) {
+  SpecsBuffer buf;
+  buf.Load(modelFile.c_str());
+  parseBuffer(buf);
+}
+
+MachineModel::MachineModel(SpecsBuffer &buf) { parseBuffer(buf); }
 
 InstType MachineModel::GetInstTypeByName(const string &typeName,
                                          const string &prevName) const {

--- a/lib/Scheduler/machine_model.cpp
+++ b/lib/Scheduler/machine_model.cpp
@@ -17,6 +17,31 @@ using std::vector;
 MachineModel::MachineModel(const std::string &modelFile) {
   SpecsBuffer buf;
   buf.Load(modelFile.c_str());
+
+  char buffer[MAX_NAMESIZE];
+
+  buf.ReadSpec("MODEL_NAME:", buffer);
+  mdlName_ = buffer;
+
+  issueRate_ = buf.ReadIntSpec("ISSUE_RATE:");
+
+  int numIssueTypes = buf.ReadIntSpec("ISSUE_TYPE_COUNT:");
+
+  issueTypes_.resize(numIssueTypes > 0 ? numIssueTypes : 1);
+  if (numIssueTypes > 0) {
+    for (size_t j = 0; j < issueTypes_.size(); j++) {
+      int pieceCnt;
+      char *strngs[INBUF_MAX_PIECES_PERLINE];
+      int lngths[INBUF_MAX_PIECES_PERLINE];
+      buf.GetNxtVldLine(pieceCnt, strngs, lngths);
+
+      if (pieceCnt != 2)
+        llvm::report_fatal_error("Invalid issue type spec", false);
+
+      issueTypes_[j].name = strngs[0];
+      issueTypes_[j].slotsCount = atoi(strngs[1]);
+    }
+  }
 }
 
 MachineModel::MachineModel(SpecsBuffer &buf) {


### PR DESCRIPTION
Hey --

Currently the master branch has a runtime issue from one of the last few commits. I don't really have the time to fully investigate why the bug is occurring, but the error is essentially that SetupForSchduling uses `issueTypes_.size()` before it is initialized. I believe this has something to do with a change in the way the machine model is constructed, but I am not sure.

This PR forces initialization of the vector by loading in the MM config file. If anyone knows off the top of their head what the culprit is, I can modify, otherwise I'll merge soon.

The key idea here is that any new team members won't need to debug the code before they are able to set up their environments.