### PR TITLE
Support using a custom value for occupancy limit across all kernels

### DIFF
--- a/example/optsched-cfg/sched.ini
+++ b/example/optsched-cfg/sched.ini
@@ -341,6 +341,7 @@ SHOULD_LIMIT_OCCUPANCY YES
 
 # What should we use to limit the occupancy?
 # HEURISTIC: AMD's memory boundedness heuristic
+# VALUE: Uses the value provided by OCCUPANCY_LIMIT for all kernels
 # FILE: occupancy_limits.ini file
 # NONE: do not use limits -- defaults to unlimited
 OCCUPANCY_LIMIT_SOURCE FILE

--- a/include/opt-sched/Scheduler/defines.h
+++ b/include/opt-sched/Scheduler/defines.h
@@ -49,6 +49,8 @@ enum FUNC_RESULT {
 enum OCC_LIMIT_TYPE {
   // NONE
   OLT_NONE,
+  // Value provided by sched.ini
+  OLT_VALUE,
   // AMD's Heuristic
   OLT_HEUR,
   // Hardcoded File

--- a/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
+++ b/lib/Wrapper/AMDGPU/OptSchedGCNTarget.cpp
@@ -222,6 +222,8 @@ int OptSchedGCNTarget::getOccupancyLimit(Config &OccFile) const {
   switch (LimitType) {
   case OLT_NONE:
     return OCCUnlimited;
+  case OLT_VALUE:
+    return OccupancyLimit;
   case OLT_HEUR:
     return MFI->isMemoryBound() || MFI->needsWaveLimiter() ? 4 : OCCUnlimited;
   case OLT_FILE:

--- a/lib/Wrapper/OptimizingScheduler.cpp
+++ b/lib/Wrapper/OptimizingScheduler.cpp
@@ -860,6 +860,8 @@ ScheduleDAGOptSched::parseOccLimit(const std::string Str) {
 
   if (Str == "NONE") {
     return OCC_LIMIT_TYPE::OLT_NONE;
+  } else if (Str = "VALUE") {
+    return OCC_LIMIT_TYPE::OLT_VALUE;
   } else if (Str == "HEURISTIC") {
     return OCC_LIMIT_TYPE::OLT_HEUR;
   } else if (Str == "FILE") {


### PR DESCRIPTION
This PR implements some logic to bring in support for using `OCCUPANCY_LIMIT` to set a custom limit of occupancy for all kernels. To use this option, set `OCCUPANCY_LIMIT_SOURCE` to `VALUE`